### PR TITLE
Improve virtual camera compatibility.

### DIFF
--- a/source/dshow-enum.cpp
+++ b/source/dshow-enum.cpp
@@ -457,9 +457,8 @@ static bool EnumDevice(const GUID &type, IMoniker *deviceInfo,
 		return true;
 	}
 
+	/* devicePath maybe empty for some virtual camera */
 	hr = propertyData->Read(L"DevicePath", &devicePath, NULL);
-	if (FAILED(hr))
-		return true;
 
 	hr = deviceInfo->BindToObject(NULL, 0, IID_IBaseFilter,
 			(void**)&filter);


### PR DESCRIPTION
1)Device path is empty for some virtual camera. So we ignore it when enumerate devices.
2)Media sample received without timestamp. So we try to fix it from IMediaFilter.