### PR TITLE
libdshowcapture: Add frame interval tolerance

### DIFF
--- a/source/dshow-enum.cpp
+++ b/source/dshow-enum.cpp
@@ -223,10 +223,11 @@ static bool ClosestVideoMTCallback(ClosestVideoData &data,
 	else if (data.config.cy > info.maxCY)
 		yVal = data.config.cy - info.maxCY;
 
-	if (data.config.frameInterval < info.minInterval)
-		frameVal = info.minInterval - data.config.frameInterval;
-	else if (data.config.frameInterval > info.maxInterval)
-		frameVal = data.config.frameInterval - info.maxInterval;
+	const long long frameInterval = data.config.frameInterval;
+	if (frameInterval < info.minInterval)
+		frameVal = info.minInterval - frameInterval;
+	else if (frameInterval > info.maxInterval)
+		frameVal = frameInterval - info.maxInterval;
 
 	formatVal = GetFormatRating(info.format);
 
@@ -245,8 +246,11 @@ static bool ClosestVideoMTCallback(ClosestVideoData &data,
 					   info.granularityCY);
 		}
 
-		if (frameVal == 0)
-			vih->AvgTimePerFrame = data.config.frameInterval;
+		if (frameVal == 0) {
+			// Close enough. Fixes GV-USB2 29.97 FPS setting.
+			if (abs(vih->AvgTimePerFrame - frameInterval) > 1)
+				vih->AvgTimePerFrame = frameInterval;
+		}
 
 		data.found = true;
 		data.bestVal = totalVal;


### PR DESCRIPTION
### Description
Some devices like GV-USB2 can be very finicky about the frame interval,
accepting 333667 but not 333666. If it's wihtin 100 nanoseconds, just
let it slide.

### Motivation and Context
Selecting 29.97 FPS now works for GV-USB2.

### How Has This Been Tested?
Black screen without the change, and video feed with the change. Setting is preserved after relaunching OBS.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.