### PR TITLE
libdshowcapture: Support bottom-up DIBs

### DIFF
--- a/dshowcapture.hpp
+++ b/dshowcapture.hpp
@@ -161,8 +161,11 @@ struct Config : DeviceId {
 struct VideoConfig : Config {
 	VideoProc callback;
 
-	/** Desired width/height of video.  */
-	int cx = 0, cy = 0;
+	/** Desired width/height of video. */
+	int cx = 0, cy_abs = 0;
+
+	/** Whether or not cy was negative. */
+	bool cy_flip = false;
 
 	/** Desired frame interval (in 100-nanosecond units) */
 	long long frameInterval = 0;

--- a/source/device.cpp
+++ b/source/device.cpp
@@ -163,7 +163,8 @@ void HDevice::ConvertVideoSettings()
 		Debug(L"Video media type changed");
 
 		videoConfig.cx = bmih->biWidth;
-		videoConfig.cy = bmih->biHeight;
+		videoConfig.cy_abs = labs(bmih->biHeight);
+		videoConfig.cy_flip = bmih->biHeight < 0;
 		videoConfig.frameInterval = vih->AvgTimePerFrame;
 
 		bool same = videoConfig.internalFormat == videoConfig.format;

--- a/source/dshow-encoded-device.cpp
+++ b/source/dshow-encoded-device.cpp
@@ -218,7 +218,8 @@ bool HDevice::SetupEncodedVideoCapture(IBaseFilter *filter, VideoConfig &config,
 		return false;
 
 	config.cx = info.width;
-	config.cy = info.height;
+	config.cy_abs = labs(info.height);
+	config.cy_flip = info.height < 0;
 	config.frameInterval = info.frameInterval;
 	config.format = info.videoFormat;
 	config.internalFormat = info.videoFormat;

--- a/source/dshow-enum.cpp
+++ b/source/dshow-enum.cpp
@@ -218,10 +218,12 @@ static bool ClosestVideoMTCallback(ClosestVideoData &data,
 	else if (data.config.cx > info.maxCX)
 		xVal = data.config.cx - info.maxCX;
 
-	if (data.config.cy < info.minCY)
-		yVal = info.minCY - data.config.cy;
-	else if (data.config.cy > info.maxCY)
-		yVal = data.config.cy - info.maxCY;
+	const int absMinCY = abs(info.minCY);
+	const int absMaxCY = abs(info.maxCY);
+	if (data.config.cy_abs < absMinCY)
+		yVal = absMinCY - data.config.cy_abs;
+	else if (data.config.cy_abs > absMaxCY)
+		yVal = data.config.cy_abs - absMaxCY;
 
 	const long long frameInterval = data.config.frameInterval;
 	if (frameInterval < info.minInterval)
@@ -241,9 +243,11 @@ static bool ClosestVideoMTCallback(ClosestVideoData &data,
 		}
 
 		if (yVal == 0) {
-			bmih->biHeight = data.config.cy;
-			ClampToGranularity(bmih->biHeight, info.minCY,
+			LONG cy_abs_clamp = data.config.cy_abs;
+			ClampToGranularity(cy_abs_clamp, info.minCY,
 					   info.granularityCY);
+			bmih->biHeight = data.config.cy_flip ? -cy_abs_clamp
+							     : cy_abs_clamp;
 		}
 
 		if (frameVal == 0) {


### PR DESCRIPTION
### Description
The biHeight field can be negative, leading to crashes on some cards
like VisionRGB-E1S. Adding flip support is fairly straightforward.

See: https://docs.microsoft.com/en-us/windows/win32/directshow/top-down-vs--bottom-up-dibs

### Motivation and Context
Fix crash on VisionRGB-E1S, and support negative heights robustly.

### How Has This Been Tested?
VisionRGB-E1S does not crash any more, and appears vertically correct.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to change)

(The breaking change will come in a separate PR for the main project. There appears to be a hack in win-dshow to automatically flip for RGB formats, but I wish to remove it because it seems to fight with this change. We already have a separate vertical flip checkbox to deal with non-compliant behavior.)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.