### PR TITLE
Explicit loop to avoid invalid callback signature

### DIFF
--- a/source/dshow-base.cpp
+++ b/source/dshow-base.cpp
@@ -513,8 +513,8 @@ static HRESULT DevicePathToDeviceInstancePath(const wchar_t *devicePath,
 
 	/* Convert to uppercase STL string */
 	wstring parseDevicePath = devicePath;
-	std::transform(parseDevicePath.begin(), parseDevicePath.end(),
-		       parseDevicePath.begin(), ::toupper);
+	for (wchar_t &c : parseDevicePath)
+		c = (wchar_t)toupper(c);
 
 	/* Find start position ('\\?\' or '\?\') */
 	wstring startToken = L"\\\\?\\";


### PR DESCRIPTION
### Description
Add explicit loop to avoid invalid callback signature

std::transform implicitly truncates int to wchar_t, and causes a
warning. Writing the loop manually allows us to provide a cast.

### Motivation and Context
Fix compiler warning.

### How Has This Been Tested?
Debugger inspection. String is properly upper'd before and after change.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.