### PR TITLE
Fix missing assignment operator return

### DIFF
--- a/dshowcapture.hpp
+++ b/dshowcapture.hpp
@@ -31,7 +31,7 @@
 
 #define DSHOWCAPTURE_VERSION_MAJOR 0
 #define DSHOWCAPTURE_VERSION_MINOR 7
-#define DSHOWCAPTURE_VERSION_PATCH 0
+#define DSHOWCAPTURE_VERSION_PATCH 1
 
 #define MAKE_DSHOWCAPTURE_VERSION(major, minor, patch) \
 	((major << 24) | (minor << 16) | (patch))

--- a/source/CoTaskMemPtr.hpp
+++ b/source/CoTaskMemPtr.hpp
@@ -37,6 +37,7 @@ public:
 	{
 		Clear();
 		ptr = val;
+		return *this;
 	}
 
 	inline T **operator&()


### PR DESCRIPTION
### Description
Fix missing assignment operator return

### Motivation and Context
PVS-Studio warning.

### How Has This Been Tested?
Nothing calls it since even garbage compiles, but this is standard convention.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.