### PR TITLE
Add mode for audio disabling

### DIFF
--- a/dshowcapture.hpp
+++ b/dshowcapture.hpp
@@ -115,6 +115,7 @@ enum class AudioMode {
 	Capture,
 	DirectSound,
 	WaveOut,
+	Disable,
 };
 
 enum class Result {


### PR DESCRIPTION
### Description
This adds an AudioMode whereby audio will be disabled.

### Motivation and Context
By request of Fenrir and Energizerfellow.

### How Has This Been Tested?
In vs2017 win 10 2004 x64.

### Types of changes
 - New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
