### PR TITLE
Output Filter: Fix null pointer dereference, and don't hold graph reference

### DIFF
--- a/source/output-filter.cpp
+++ b/source/output-filter.cpp
@@ -651,6 +651,7 @@ OutputFilter::OutputFilter(VideoFormat format, int cx, int cy,
 			   long long interval)
 	: refCount(0),
 	  state(State_Stopped),
+	  graph(nullptr),
 	  pin(new OutputPin(this, format, cx, cy, interval)),
 	  misc(new SourceMiscFlags)
 {

--- a/source/output-filter.cpp
+++ b/source/output-filter.cpp
@@ -348,6 +348,9 @@ STDMETHODIMP OutputPin::SetFormat(AM_MEDIA_TYPE *pmt)
 {
 	PrintFunc(L"OutputPin::SetFormat");
 
+	if (pmt == nullptr)
+		return VFW_E_INVALIDMEDIATYPE;
+
 	mt = pmt;
 
 	GetMediaTypeVFormat(mt, curVFormat);

--- a/source/output-filter.hpp
+++ b/source/output-filter.hpp
@@ -134,7 +134,7 @@ class OutputFilter : public IBaseFilter {
 
 	volatile long refCount;
 	FILTER_STATE state;
-	ComPtr<IFilterGraph> graph;
+	IFilterGraph *graph;
 	ComPtr<OutputPin> pin;
 
 	ComPtr<IAMFilterMiscFlags> misc;


### PR DESCRIPTION
### Description

Allow format on a `IAMStreamConfig::SetFormat()` call to be nullptr. According to the [documentation](https://docs.microsoft.com/en-us/windows/win32/api/strmif/nf-strmif-iamstreamconfig-setformat)

> With some filters, you can call this method with the value NULL to reset the pin to its default format.

So OBS should atleast not crash - returning a failure code to the application and keeping current state.

After this crash was fixes I found another issue when using the Virtual Cam from Resolume. When the filter was unloaded and the graph reset, the ComPtr object would release the filtergraph and that resulted in another call to `JoinFilterGraph(IFilterGraph *pGraph, LPCWSTR pName)` with a nullptr pGraph.

According to the [documentation](https://docs.microsoft.com/en-us/windows/win32/api/strmif/nf-strmif-ibasefilter-joinfiltergraph):
> **Filter developers:** The filter can store the **IFilterGraph** interface pointer and query it for other Filter Graph Manager interfaces. However, it must never hold a reference count on the Filter Graph Manager. Doing so creates a circular reference count, because the Filter Graph Manager keeps a reference count on the filter. A circular reference count prevents the interface from being released properly, which can lead to a deadlock. The **IFilterGraph** interface is guaranteed to be valid until the Filter Graph Manager calls this method again with the value **NULL**. For an implementation of this method, see the CBaseFilter::JoinFilterGraph method.

### Motivation and Context

Resolume calls `SetFormat(null)` to reset a filter to its initial format. As per docs this should be supported or fail.

Resolume loads and unloads DirectShow capture sources when switching between Decks. To not waste resources on things that are not used all the time.

### How Has This Been Tested?

This was tested by rebuildling the project and copying the debug version of the obs virtual cam over the current version. Running our debug builds of Resolume to identify these problems and then fix them.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
