### PR TITLE
Improve logic to match audio and video inputs

### DIFF
--- a/source/dshow-base.cpp
+++ b/source/dshow-base.cpp
@@ -852,7 +852,7 @@ static bool MatchFriendlyNames(const wchar_t *vidName, const wchar_t *audName)
 
 	/* Remove 'video' from friendly name */
 	size_t posVid;
-	wstring searchVid[] = {L"(video) ", L"(video)", L"video ", L"video"};
+	wstring searchVid[] = {L"(video) ", L"(video)", L"video ", L"video", L"hdmi", L" / multiview"};
 	for (int i = 0; i < _ARRAYSIZE(searchVid); i++) {
 		wstring &search = searchVid[i];
 		while ((posVid = strVidName.find(search)) !=


### PR DESCRIPTION
### Description
Even further improve logic to automatically match audio and video inputs to each other if they are implemented by separate DirectShow filters.

### Motivation and Context
A change to match audio and video inputs that belong to the same hardware device had to be further improved.

### How Has This Been Tested?
Tested on Windows 10 with different Elgato capture devices.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.