### PR TITLE
Add support of RGB24 format

### DIFF
--- a/dshowcapture.hpp
+++ b/dshowcapture.hpp
@@ -79,6 +79,7 @@ enum class VideoFormat {
 	/* raw formats */
 	ARGB = 100,
 	XRGB,
+	RGB24,
 
 	/* planar YUV formats */
 	I420 = 200,

--- a/source/device.cpp
+++ b/source/device.cpp
@@ -326,6 +326,8 @@ bool HDevice::SetupVideoCapture(IBaseFilter *filter, VideoConfig &config)
 		info.expectedSubType = MEDIASUBTYPE_RGB32;
 	else if (videoConfig.format == VideoFormat::ARGB)
 		info.expectedSubType = MEDIASUBTYPE_ARGB32;
+	else if (videoConfig.format == VideoFormat::RGB24)
+		info.expectedSubType = MEDIASUBTYPE_RGB24;
 	else if (videoConfig.format == VideoFormat::YVYU)
 		info.expectedSubType = MEDIASUBTYPE_YVYU;
 	else if (videoConfig.format == VideoFormat::YUY2)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
Add support of RGB24 format, which is compatible with [PixelFormats.Bgr24](https://docs.microsoft.com/en-us/dotnet/api/system.windows.media.pixelformats.bgr24?view=net-5.0).


<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Currently, only XRGB (`MEDIASUBTYPE_RGB32`) is supported, which has one byte wasted. 

Adding support for RGB24 is easy, and it is a good-to-have feature. 

In machine learning objection detection applications, smaller array sizes can speed up the transcoding of bitmaps to vectors, resulting in higher FPS. 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on Windows 10 20H2 (19042.804) with Elago HD60 Pro capture card. 

Tested using my .NET wrapper here: [NetLibDirectshowCapture](https://github.com/charlescao460/NetLibDirectshowCapture)
When `VideoConfig::internalFormat` is `XRGB` or `YUY2`, it can successfully produce RGB24 array. 

Results screenshot:
![image](https://user-images.githubusercontent.com/33741854/109408322-7ca0e680-7956-11eb-8c31-1c1408fe6013.png)


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
