### PR TITLE
Add support for ASUS coupled audio

### DIFF
--- a/source/dshow-base.cpp
+++ b/source/dshow-base.cpp
@@ -693,6 +693,7 @@ static bool IsUncoupledDevice(const wchar_t *vidDevInstPath)
 	wstring usbVidIdWhitelist[] = {
 		L"0FD9", /* elgato */
 		L"3842", /* evga */
+		L"0B05", /* asus */
 	};
 
 	if (MatchingStartToken(path, usbToken)) {


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This commit adds ASUS' USB vendor ID to the list for UVC device audio coupling.


### Motivation and Context
Avoid having to manually set audio device to get audio capture from USB capture cards

### How Has This Been Tested?
Compiled and tested on windows 10 that audio is captured

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
 New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
