### PR TITLE
Implement FindPin

### DIFF
--- a/source/capture-filter.cpp
+++ b/source/capture-filter.cpp
@@ -501,9 +501,17 @@ STDMETHODIMP CaptureFilter::FindPin(LPCWSTR Id, IPin **ppPin)
 {
 	PrintFunc(L"CaptureFilter::FindPin");
 
-	DSHOW_UNUSED(Id);
-	DSHOW_UNUSED(ppPin);
-	return E_NOTIMPL;
+	if (Id == nullptr || ppPin == nullptr)
+		return E_POINTER;
+
+	if (lstrcmpW(Id, CAPTURE_PIN_NAME) == 0) {
+		*ppPin = pin;
+		pin->AddRef();
+		return S_OK;
+	} else {
+		*ppPin = nullptr;
+		return VFW_E_NOT_FOUND;
+	}
 }
 
 STDMETHODIMP CaptureFilter::QueryFilterInfo(FILTER_INFO *pInfo)

--- a/source/output-filter.cpp
+++ b/source/output-filter.cpp
@@ -778,9 +778,17 @@ STDMETHODIMP OutputFilter::FindPin(LPCWSTR Id, IPin **ppPin)
 {
 	PrintFunc(L"OutputFilter::FindPin");
 
-	DSHOW_UNUSED(Id);
-	DSHOW_UNUSED(ppPin);
-	return E_NOTIMPL;
+	if (Id == nullptr || ppPin == nullptr)
+		return E_POINTER;
+
+	if (lstrcmpW(Id, OUTPUT_PIN_NAME) == 0) {
+		*ppPin = pin;
+		pin->AddRef();
+		return S_OK;
+	} else {
+		*ppPin = nullptr;
+		return VFW_E_NOT_FOUND;
+	}
 }
 
 STDMETHODIMP OutputFilter::QueryFilterInfo(FILTER_INFO *pInfo)


### PR DESCRIPTION
* Implement IBaseFilter::FindPin for output-filter and capture-filter

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
For output-filter and capture-filter, this PR implements IBaseFilter:FindPin. Since those filters will only have
one pin, it will compare the pins name with the given id and just return that pin. Handling occurs according to the [Microsoft Docs on FindPin](https://docs.microsoft.com/en-us/windows/win32/api/strmif/nf-strmif-ibasefilter-findpin).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This fixes https://github.com/obsproject/obs-studio/issues/4721.

### How Has This Been Tested?
This should not affect any other areas. In a test program, I called FindPin with different strings for id (some matching, others not) and null and also some IPin* or null. Everything worked according to the FindPin docs. I tested output filter, but capture filter works exactly the same.

### Types of changes
Bug fix

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
