### PR TITLE
Setup the desired sampleRate

### DIFF
--- a/source/device.cpp
+++ b/source/device.cpp
@@ -468,6 +468,16 @@ bool HDevice::SetupAudioCapture(IBaseFilter *filter, AudioConfig &config)
 			Error(L"Could not get closest audio media type");
 			return false;
 		}
+	} else {
+		// useDefaultConfig case
+		if (config.sampleRate != 0) {
+			WAVEFORMATEX *wfex = reinterpret_cast<WAVEFORMATEX *>(
+				audioMediaType->pbFormat);
+			// set the desired sampleRate
+			wfex->nSamplesPerSec = config.sampleRate;
+			Debug(L"\tdesired sampleRate = %d", config.sampleRate);
+			wfex->nAvgBytesPerSec = wfex->nSamplesPerSec * wfex->nBlockAlign;
+		}
 	}
 
 	if (!!pinConfig) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

try to set the desired sampling rate.

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

 this fix try to set the desired sampling rate by modifying `nSamplesPerSec`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

I'm not sure but when using a video capture card (`MJPEG` only ) with a USB audio support (like as ATEM mini)
with Custom Audio setting. OBS does not set/report the correct sampling rate for the selected audio device as follows.

```
20:13:11.138: [DShow Device: 'ATEMMini'] settings updated:
20:13:11.138: video device: Blackmagic Design
...
20:13:11.138: resolution: 1920x1080
20:13:11.138: flip: 0
20:13:11.138: fps: 60.00 (interval: 166667)
20:13:11.138: format: MJPEG
20:13:11.154: using video device audio: no
20:13:11.154: audio device: Mic (Blackmagic Design)
20:13:11.154: separate audio filter
20:13:11.154: sample rate: 44100 // <-- wrong
20:13:11.154: channels: 2
20:13:11.154: audio type: Capture
```

and the result of this situation (I guess)
 * frequent audio out of sync while broadcasting
 * need to deactivate/activate again and again to make it work properly.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

 * OBS sampling rate profile: `48 kHz`
 * Video/audio capture cards like the Blackmagic Atem mini (Video - MJPEG, Audio - USB audio)
 * Select custom audio device to its USB audio device
 * broadcasting with these settings results in audio quality problems.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

This quick hack try to set the desired sampling rate by modifying `nSamplesPerSec`

See also
 * https://social.msdn.microsoft.com/Forums/windowsdesktop/en-US/9d61c9c0-9e0d-4ed6-81dd-f9f9b174dee5/specifying-audio-settings-bits-sample-rate-etc-when-capturing-video?forum=windowsdirectshowdevelopment
 * https://titanwolf.org/Network/Articles/Article?AID=8cf7dc88-9fe9-4c0e-8a0f-ff484f68e0e4#gsc.tab=0


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
