### PR TITLE
Add CLSID to help find same device

### DIFF
--- a/dshowcapture.hpp
+++ b/dshowcapture.hpp
@@ -142,6 +142,7 @@ struct AudioInfo {
 struct DeviceId {
 	std::wstring name;
 	std::wstring path;
+	std::wstring clsid;
 };
 
 struct VideoDevice : DeviceId {

--- a/source/device.cpp
+++ b/source/device.cpp
@@ -367,7 +367,7 @@ bool HDevice::SetVideoConfig(VideoConfig *config)
 
 	bool success = GetDeviceFilter(CLSID_VideoInputDeviceCategory,
 				       config->name.c_str(),
-				       config->path.c_str(), 
+				       config->path.c_str(),
 				       config->clsid.c_str(), &filter);
 	if (!success) {
 		Error(L"Video device '%s': %s not found", config->name.c_str(),
@@ -571,7 +571,7 @@ bool HDevice::SetAudioConfig(AudioConfig *config)
 	} else {
 		bool success = GetDeviceFilter(CLSID_AudioInputDeviceCategory,
 					       config->name.c_str(),
-					       config->path.c_str(), 
+					       config->path.c_str(),
 					       config->clsid.c_str(), &filter);
 		if (!success) {
 			Error(L"Audio device '%s': %s not found",

--- a/source/device.cpp
+++ b/source/device.cpp
@@ -367,7 +367,8 @@ bool HDevice::SetVideoConfig(VideoConfig *config)
 
 	bool success = GetDeviceFilter(CLSID_VideoInputDeviceCategory,
 				       config->name.c_str(),
-				       config->path.c_str(), &filter);
+				       config->path.c_str(), 
+				       config->clsid.c_str(), &filter);
 	if (!success) {
 		Error(L"Video device '%s': %s not found", config->name.c_str(),
 		      config->path.c_str());
@@ -570,7 +571,8 @@ bool HDevice::SetAudioConfig(AudioConfig *config)
 	} else {
 		bool success = GetDeviceFilter(CLSID_AudioInputDeviceCategory,
 					       config->name.c_str(),
-					       config->path.c_str(), &filter);
+					       config->path.c_str(), 
+					       config->clsid.c_str(), &filter);
 		if (!success) {
 			Error(L"Audio device '%s': %s not found",
 			      config->name.c_str(), config->path.c_str());

--- a/source/dshow-base.cpp
+++ b/source/dshow-base.cpp
@@ -108,16 +108,21 @@ struct DeviceFilterCallbackInfo {
 	ComPtr<IBaseFilter> filter;
 	const wchar_t *name;
 	const wchar_t *path;
+	const wchar_t* clsid;
 };
 
 static bool GetDeviceCallback(DeviceFilterCallbackInfo &info,
 			      IBaseFilter *filter, const wchar_t *name,
-			      const wchar_t *path)
+			      const wchar_t *path, const wchar_t* clsid)
 {
 	if (info.name && *info.name && wcscmp(name, info.name) != 0)
 		return true;
 
 	info.filter = filter;
+
+	/* break if CLSID is same */
+	if (info.clsid && *info.clsid && clsid && *clsid && wcscmp(clsid, info.clsid) == 0)
+		return false;
 
 	/* continue if path does not match */
 	if (!path || !info.path || wcscmp(path, info.path) != 0)
@@ -126,12 +131,13 @@ static bool GetDeviceCallback(DeviceFilterCallbackInfo &info,
 	return false;
 }
 
-bool GetDeviceFilter(const IID &type, const wchar_t *name, const wchar_t *path,
+bool GetDeviceFilter(const IID &type, const wchar_t *name, const wchar_t *path, const wchar_t* clsid,
 		     IBaseFilter **out)
 {
 	DeviceFilterCallbackInfo info;
 	info.name = name;
 	info.path = path;
+	info.clsid = clsid;
 
 	if (!EnumDevices(type, EnumDeviceCallback(GetDeviceCallback), &info))
 		return false;

--- a/source/dshow-base.cpp
+++ b/source/dshow-base.cpp
@@ -108,12 +108,12 @@ struct DeviceFilterCallbackInfo {
 	ComPtr<IBaseFilter> filter;
 	const wchar_t *name;
 	const wchar_t *path;
-	const wchar_t* clsid;
+	const wchar_t *clsid;
 };
 
 static bool GetDeviceCallback(DeviceFilterCallbackInfo &info,
 			      IBaseFilter *filter, const wchar_t *name,
-			      const wchar_t *path, const wchar_t* clsid)
+			      const wchar_t *path, const wchar_t *clsid)
 {
 	if (info.name && *info.name && wcscmp(name, info.name) != 0)
 		return true;
@@ -121,7 +121,8 @@ static bool GetDeviceCallback(DeviceFilterCallbackInfo &info,
 	info.filter = filter;
 
 	/* break if CLSID is same */
-	if (info.clsid && *info.clsid && clsid && *clsid && wcscmp(clsid, info.clsid) == 0)
+	if (info.clsid && *info.clsid && clsid && *clsid &&
+	    wcscmp(clsid, info.clsid) == 0)
 		return false;
 
 	/* continue if path does not match */
@@ -131,8 +132,8 @@ static bool GetDeviceCallback(DeviceFilterCallbackInfo &info,
 	return false;
 }
 
-bool GetDeviceFilter(const IID &type, const wchar_t *name, const wchar_t *path, const wchar_t* clsid,
-		     IBaseFilter **out)
+bool GetDeviceFilter(const IID &type, const wchar_t *name, const wchar_t *path,
+		     const wchar_t *clsid, IBaseFilter **out)
 {
 	DeviceFilterCallbackInfo info;
 	info.name = name;

--- a/source/dshow-base.hpp
+++ b/source/dshow-base.hpp
@@ -44,8 +44,8 @@ bool CreateFilterGraph(IGraphBuilder **graph, ICaptureGraphBuilder2 **builder,
 
 void LogFilters(IGraphBuilder *graph);
 
-bool GetDeviceFilter(const IID &type, const wchar_t *name, const wchar_t *path, const wchar_t* clsid,
-		     IBaseFilter **filter);
+bool GetDeviceFilter(const IID &type, const wchar_t *name, const wchar_t *path,
+		     const wchar_t *clsid, IBaseFilter **filter);
 
 bool GetFilterPin(IBaseFilter *filter, const GUID &type, const GUID &category,
 		  PIN_DIRECTION dir, IPin **pin);

--- a/source/dshow-base.hpp
+++ b/source/dshow-base.hpp
@@ -44,7 +44,7 @@ bool CreateFilterGraph(IGraphBuilder **graph, ICaptureGraphBuilder2 **builder,
 
 void LogFilters(IGraphBuilder *graph);
 
-bool GetDeviceFilter(const IID &type, const wchar_t *name, const wchar_t *path,
+bool GetDeviceFilter(const IID &type, const wchar_t *name, const wchar_t *path, const wchar_t* clsid,
 		     IBaseFilter **filter);
 
 bool GetFilterPin(IBaseFilter *filter, const GUID &type, const GUID &category,

--- a/source/dshow-enum.cpp
+++ b/source/dshow-enum.cpp
@@ -509,8 +509,7 @@ static recursive_mutex enumMutex;
 
 static bool CheckForDLCallback(void *unused, IBaseFilter *filter,
 			       const wchar_t *deviceName,
-			       const wchar_t *devicePath, 
-			       const wchar_t* clsid)
+			       const wchar_t *devicePath, const wchar_t *clsid)
 {
 	if (wcsstr(deviceName, L"Decklink") != nullptr) {
 		decklinkVideoPresent = true;

--- a/source/dshow-enum.hpp
+++ b/source/dshow-enum.hpp
@@ -39,7 +39,8 @@ bool EnumAudioCaps(IPin *pin, vector<AudioInfo> &caps);
 
 typedef bool (*EnumDeviceCallback)(void *param, IBaseFilter *filter,
 				   const wchar_t *deviceName,
-				   const wchar_t *devicePath);
+				   const wchar_t *devicePath,
+				   const wchar_t* deviceCLSID);
 
 bool EnumDevices(const GUID &type, EnumDeviceCallback callback, void *param);
 

--- a/source/dshow-enum.hpp
+++ b/source/dshow-enum.hpp
@@ -40,7 +40,7 @@ bool EnumAudioCaps(IPin *pin, vector<AudioInfo> &caps);
 typedef bool (*EnumDeviceCallback)(void *param, IBaseFilter *filter,
 				   const wchar_t *deviceName,
 				   const wchar_t *devicePath,
-				   const wchar_t* deviceCLSID);
+				   const wchar_t *deviceCLSID);
 
 bool EnumDevices(const GUID &type, EnumDeviceCallback callback, void *param);
 

--- a/source/dshowcapture.cpp
+++ b/source/dshowcapture.cpp
@@ -221,7 +221,7 @@ static void EnumExceptionVideoDevice(std::vector<VideoDevice> &devices,
 
 static bool EnumVideoDevice(std::vector<VideoDevice> &devices,
 			    IBaseFilter *filter, const wchar_t *deviceName,
-			    const wchar_t *devicePath)
+			    const wchar_t *devicePath, const wchar_t* clsid)
 {
 	ComPtr<IPin> pin;
 	ComPtr<IPin> audioPin;
@@ -268,6 +268,8 @@ static bool EnumVideoDevice(std::vector<VideoDevice> &devices,
 	info.name = deviceName;
 	if (devicePath)
 		info.path = devicePath;
+	if (clsid)
+		info.clsid = clsid;
 
 	devices.push_back(info);
 	return true;
@@ -282,7 +284,8 @@ bool Device::EnumVideoDevices(std::vector<VideoDevice> &devices)
 
 static bool EnumAudioDevice(vector<AudioDevice> &devices, IBaseFilter *filter,
 			    const wchar_t *deviceName,
-			    const wchar_t *devicePath)
+			    const wchar_t *devicePath, 
+			    const wchar_t* clsid)
 {
 	ComPtr<IPin> pin;
 	AudioDevice info;
@@ -298,6 +301,8 @@ static bool EnumAudioDevice(vector<AudioDevice> &devices, IBaseFilter *filter,
 	info.name = deviceName;
 	if (devicePath)
 		info.path = devicePath;
+	if (clsid)
+		info.clsid = clsid;
 
 	devices.push_back(info);
 	return true;

--- a/source/dshowcapture.cpp
+++ b/source/dshowcapture.cpp
@@ -221,7 +221,7 @@ static void EnumExceptionVideoDevice(std::vector<VideoDevice> &devices,
 
 static bool EnumVideoDevice(std::vector<VideoDevice> &devices,
 			    IBaseFilter *filter, const wchar_t *deviceName,
-			    const wchar_t *devicePath, const wchar_t* clsid)
+			    const wchar_t *devicePath, const wchar_t *clsid)
 {
 	ComPtr<IPin> pin;
 	ComPtr<IPin> audioPin;
@@ -284,8 +284,7 @@ bool Device::EnumVideoDevices(std::vector<VideoDevice> &devices)
 
 static bool EnumAudioDevice(vector<AudioDevice> &devices, IBaseFilter *filter,
 			    const wchar_t *deviceName,
-			    const wchar_t *devicePath, 
-			    const wchar_t* clsid)
+			    const wchar_t *devicePath, const wchar_t *clsid)
 {
 	ComPtr<IPin> pin;
 	AudioDevice info;

--- a/source/dshowencode.cpp
+++ b/source/dshowencode.cpp
@@ -84,7 +84,7 @@ bool VideoEncoder::Encode(unsigned char *data[DSHOW_MAX_PLANES],
 static bool EnumVideoEncoder(vector<DeviceId> &encoders, IBaseFilter *encoder,
 			     const wchar_t *deviceName,
 			     const wchar_t *devicePath,
-			     const wchar_t* deviceCLSID)
+			     const wchar_t *deviceCLSID)
 {
 	DeviceId id;
 	bool validDevice = wcsstr(deviceName, L"C985") ||
@@ -95,7 +95,8 @@ static bool EnumVideoEncoder(vector<DeviceId> &encoders, IBaseFilter *encoder,
 
 	id.name = deviceName;
 	id.path = devicePath ? devicePath : L"";
-	id.clsid = deviceCLSID ? deviceCLSID : L"";;
+	id.clsid = deviceCLSID ? deviceCLSID : L"";
+	;
 	encoders.push_back(id);
 
 	(void)encoder;

--- a/source/dshowencode.cpp
+++ b/source/dshowencode.cpp
@@ -83,7 +83,8 @@ bool VideoEncoder::Encode(unsigned char *data[DSHOW_MAX_PLANES],
 
 static bool EnumVideoEncoder(vector<DeviceId> &encoders, IBaseFilter *encoder,
 			     const wchar_t *deviceName,
-			     const wchar_t *devicePath)
+			     const wchar_t *devicePath,
+			     const wchar_t* deviceCLSID)
 {
 	DeviceId id;
 	bool validDevice = wcsstr(deviceName, L"C985") ||
@@ -93,7 +94,8 @@ static bool EnumVideoEncoder(vector<DeviceId> &encoders, IBaseFilter *encoder,
 		return true;
 
 	id.name = deviceName;
-	id.path = devicePath;
+	id.path = devicePath ? devicePath : L"";
+	id.clsid = deviceCLSID ? deviceCLSID : L"";;
 	encoders.push_back(id);
 
 	(void)encoder;

--- a/source/dshowencode.cpp
+++ b/source/dshowencode.cpp
@@ -96,7 +96,7 @@ static bool EnumVideoEncoder(vector<DeviceId> &encoders, IBaseFilter *encoder,
 	id.name = deviceName;
 	id.path = devicePath ? devicePath : L"";
 	id.clsid = deviceCLSID ? deviceCLSID : L"";
-	;
+
 	encoders.push_back(id);
 
 	(void)encoder;

--- a/source/encoder.cpp
+++ b/source/encoder.cpp
@@ -318,7 +318,7 @@ bool HVideoEncoder::SetConfig(VideoEncoderConfig &config)
 	}
 
 	bool success = GetDeviceFilter(KSCATEGORY_ENCODER, config.name.c_str(),
-				       config.path.c_str(), &filter);
+				       config.path.c_str(), config.clsid.c_str(), &filter);
 	if (!success) {
 		Warning(L"Video encoder '%s': %s not found",
 			config.name.c_str(), config.path.c_str());

--- a/source/encoder.cpp
+++ b/source/encoder.cpp
@@ -318,7 +318,8 @@ bool HVideoEncoder::SetConfig(VideoEncoderConfig &config)
 	}
 
 	bool success = GetDeviceFilter(KSCATEGORY_ENCODER, config.name.c_str(),
-				       config.path.c_str(), config.clsid.c_str(), &filter);
+				       config.path.c_str(),
+				       config.clsid.c_str(), &filter);
 	if (!success) {
 		Warning(L"Video encoder '%s': %s not found",
 			config.name.c_str(), config.path.c_str());

--- a/source/output-filter.cpp
+++ b/source/output-filter.cpp
@@ -22,6 +22,7 @@
 #include "log.hpp"
 
 #include <strsafe.h>
+#include <stdint.h>
 
 namespace DShow {
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
I find "DevicePath" can't represent the specific device.
For some device, its "DevicePath" may be different when connected to different USB interface.

Test device : Bluelover HD-70P
https://www.lightinthebox.com/en/p/bluelover-hd-70p-camera-cmos-webcam-720p-resolution-ratio-for-meeting-and-tv_p5075416.html

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Help find the device

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested in OBS.
Connected camera to different USB, webcam source should be captured normally aftering reboot OBS.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
