### PR TITLE
Add support for CameraControl and VideoProcAmp properties

### DIFF
--- a/dshowcapture.hpp
+++ b/dshowcapture.hpp
@@ -210,6 +210,16 @@ struct AudioConfig : Config {
 	AudioMode mode = AudioMode::Capture;
 };
 
+struct VideoDeviceProperty {
+	long property;
+	long flags;
+	long val;
+	long min;
+	long max;
+	long step;
+	long def;
+};
+
 class DSHOWCAPTURE_EXPORT Device {
 	HDevice *context;
 
@@ -224,6 +234,10 @@ public:
 
 	bool SetVideoConfig(VideoConfig *config);
 	bool SetAudioConfig(AudioConfig *config);
+	bool SetCameraControlProperties(
+		std::vector<VideoDeviceProperty> *properties);
+	bool
+	SetVideoProcAmpProperties(std::vector<VideoDeviceProperty> *properties);
 
 	/**
 		 * Connects all the configured filters together.
@@ -237,6 +251,10 @@ public:
 
 	bool GetVideoConfig(VideoConfig &config) const;
 	bool GetAudioConfig(AudioConfig &config) const;
+	bool GetCameraControlProperties(
+		std::vector<VideoDeviceProperty> &properties) const;
+	bool GetVideoProcAmpProperties(
+		std::vector<VideoDeviceProperty> &properties) const;
 	bool GetVideoDeviceId(DeviceId &id) const;
 	bool GetAudioDeviceId(DeviceId &id) const;
 

--- a/source/device.cpp
+++ b/source/device.cpp
@@ -427,6 +427,91 @@ bool HDevice::SetVideoConfig(VideoConfig *config)
 	return true;
 }
 
+bool HDevice::SetCameraControlProperties(
+	std::vector<VideoDeviceProperty> *properties)
+{
+	if (videoFilter == nullptr)
+		return false;
+
+	ComQIPtr<IAMCameraControl> pCameraControl = videoFilter;
+	if (!pCameraControl)
+		return false;
+
+	for (const auto &prop : *properties) {
+		pCameraControl->Set(prop.property, prop.val, prop.flags);
+	}
+	return true;
+}
+
+bool HDevice::SetVideoProcAmpProperties(
+	std::vector<VideoDeviceProperty> *properties)
+{
+	if (videoFilter == nullptr)
+		return false;
+
+	ComQIPtr<IAMVideoProcAmp> pVideoProcAmp = videoFilter;
+	if (!pVideoProcAmp)
+		return false;
+
+	for (const auto &prop : *properties) {
+		pVideoProcAmp->Set(prop.property, prop.val, prop.flags);
+	}
+	return true;
+}
+
+bool HDevice::GetCameraControlProperties(
+	std::vector<VideoDeviceProperty> &properties) const
+{
+
+	if (videoFilter == nullptr)
+		return false;
+
+	ComQIPtr<IAMCameraControl> pCameraControl = videoFilter;
+	if (!pCameraControl)
+		return false;
+
+	for (long i = 0; i < 256; i++) {
+		long flags, val;
+		auto hr = pCameraControl->Get(i, &val, &flags);
+		if (FAILED(hr))
+			continue;
+		VideoDeviceProperty p{};
+		p.property = i;
+		p.flags = flags;
+		p.val = val;
+		hr = pCameraControl->GetRange(i, &p.min, &p.max, &p.step,
+					      &p.def, &flags);
+		properties.push_back(p);
+	}
+	return true;
+}
+
+bool HDevice::GetVideoProcAmpProperties(
+	std::vector<VideoDeviceProperty> &properties) const
+{
+	if (videoFilter == nullptr)
+		return false;
+
+	ComQIPtr<IAMVideoProcAmp> pVideoProcAmp = videoFilter;
+	if (!pVideoProcAmp)
+		return false;
+
+	for (long i = 0; i < 256; i++) {
+		long flags, val;
+		auto hr = pVideoProcAmp->Get(i, &val, &flags);
+		if (FAILED(hr))
+			continue;
+		VideoDeviceProperty p{};
+		p.property = i;
+		p.flags = flags;
+		p.val = val;
+		hr = pVideoProcAmp->GetRange(i, &p.min, &p.max, &p.step, &p.def,
+					     &flags);
+		properties.push_back(p);
+	}
+	return true;
+}
+
 bool HDevice::SetupExceptionAudioCapture(IPin *pin)
 {
 	ComPtr<IEnumMediaTypes> enumMediaTypes;

--- a/source/device.hpp
+++ b/source/device.hpp
@@ -103,6 +103,14 @@ struct HDevice {
 
 	bool SetVideoConfig(VideoConfig *config);
 	bool SetAudioConfig(AudioConfig *config);
+	bool SetCameraControlProperties(
+		std::vector<VideoDeviceProperty> *properties);
+	bool
+	SetVideoProcAmpProperties(std::vector<VideoDeviceProperty> *properties);
+	bool GetCameraControlProperties(
+		std::vector<VideoDeviceProperty> &properties) const;
+	bool GetVideoProcAmpProperties(
+		std::vector<VideoDeviceProperty> &properties) const;
 
 	bool CreateGraph();
 	bool FindCrossbar(IBaseFilter *filter, IBaseFilter **crossbar);

--- a/source/dshowcapture.cpp
+++ b/source/dshowcapture.cpp
@@ -69,6 +69,17 @@ bool Device::SetAudioConfig(AudioConfig *config)
 	return context->SetAudioConfig(config);
 }
 
+bool Device::SetCameraControlProperties(
+	std::vector<VideoDeviceProperty> *properties)
+{
+	return context->SetCameraControlProperties(properties);
+}
+bool Device::SetVideoProcAmpProperties(
+	std::vector<VideoDeviceProperty> *properties)
+{
+	return context->SetVideoProcAmpProperties(properties);
+}
+
 bool Device::ConnectFilters()
 {
 	return context->ConnectFilters();
@@ -91,6 +102,18 @@ bool Device::GetVideoConfig(VideoConfig &config) const
 
 	config = context->videoConfig;
 	return true;
+}
+
+bool Device::GetCameraControlProperties(
+	std::vector<VideoDeviceProperty> &properties) const
+{
+	return context->GetCameraControlProperties(properties);
+}
+
+bool Device::GetVideoProcAmpProperties(
+	std::vector<VideoDeviceProperty> &properties) const
+{
+	return context->GetVideoProcAmpProperties(properties);
 }
 
 bool Device::GetAudioConfig(AudioConfig &config) const


### PR DESCRIPTION
### Description

### Motivation and Context
Allow to load and save camera device properties

### How Has This Been Tested?
with an option to save the properties on the video capture device "dshow_input" source

### Types of changes
- New feature (non-breaking change which adds functionality) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
