### PR TITLE
Add P010 support

### DIFF
--- a/dshowcapture.hpp
+++ b/dshowcapture.hpp
@@ -86,6 +86,7 @@ enum class VideoFormat {
 	NV12,
 	YV12,
 	Y800,
+	P010,
 
 	/* packed YUV formats */
 	YVYU = 300,

--- a/source/dshow-formats.cpp
+++ b/source/dshow-formats.cpp
@@ -68,6 +68,8 @@ DWORD VFormatToFourCC(VideoFormat format)
 		return MAKEFOURCC('Y', 'V', '1', '2');
 	case VideoFormat::Y800:
 		return MAKEFOURCC('Y', '8', '0', '0');
+	case VideoFormat::P010:
+		return MAKEFOURCC('P', '0', '1', '0');
 
 	/* packed YUV formats */
 	case VideoFormat::YVYU:
@@ -108,6 +110,8 @@ GUID VFormatToSubType(VideoFormat format)
 		return MEDIASUBTYPE_YV12;
 	case VideoFormat::Y800:
 		return MEDIASUBTYPE_Y800;
+	case VideoFormat::P010:
+		return MEDIASUBTYPE_P010;
 
 	/* packed YUV formats */
 	case VideoFormat::YVYU:
@@ -272,6 +276,8 @@ bool GetMediaTypeVFormat(const AM_MEDIA_TYPE &mt, VideoFormat &format)
 		format = VideoFormat::NV12;
 	else if (mt.subtype == MEDIASUBTYPE_Y800)
 		format = VideoFormat::Y800;
+	else if (mt.subtype == MEDIASUBTYPE_P010)
+		format = VideoFormat::P010;
 
 	/* packed YUV formats */
 	else if (mt.subtype == MEDIASUBTYPE_YVYU)


### PR DESCRIPTION
### Description
Add P010 format to support HDR in the future.

### Motivation and Context
HDR support will be necessary in the future.

### How Has This Been Tested?
Verified win-dshow capture ignores P010 for now since it's not in the `videoFormatNames` array yet. Tested on PS5 with HDR output through AVerMedia Live Gamer 4K.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.