### PR TITLE
Toggle hardware tonemapper for Elgato 4K60 S+

### DIFF
--- a/source/device.cpp
+++ b/source/device.cpp
@@ -136,6 +136,9 @@ void HDevice::Receive(bool isVideo, IMediaSample *sample)
 			const bool hdr = IsVendorVideoHDR(propertySet);
 			if (deviceHdrSignal != hdr) {
 				deviceHdrSignal = hdr;
+#ifdef ENABLE_HEVC
+				SetVendorVideoFormat(propertySet, hdr);
+#endif
 				videoConfig.reactivateCallback();
 				reactivatePending = true;
 				return;
@@ -409,6 +412,9 @@ bool HDevice::SetVideoConfig(VideoConfig *config)
 	ComPtr<IKsPropertySet> propertySet = ComQIPtr<IKsPropertySet>(filter);
 	if (propertySet) {
 		const bool hdr = IsVendorVideoHDR(propertySet);
+#ifdef ENABLE_HEVC
+		SetVendorVideoFormat(propertySet, hdr);
+#endif
 		deviceHdrSignal = hdr;
 	}
 


### PR DESCRIPTION
### Description
Force off hardware tonemapper on capture card when dealing with raw HDR streams. That means off for P010, and on otherwise. We currently do not expose P010, but that will change in the future. Currently only supports some AVerMedia and Elgato cards.

### Motivation and Context
Future HDR support.

### How Has This Been Tested?
Verified video previews as expected against master (NV12) and HDR fork (NV12, P010).

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.