### PR TITLE
Add HEVC support

### DIFF
--- a/dshowcapture.hpp
+++ b/dshowcapture.hpp
@@ -99,6 +99,7 @@ enum class VideoFormat {
 	/* encoded formats */
 	MJPEG = 400,
 	H264,
+	HEVC,
 };
 
 enum class AudioFormat {

--- a/source/dshow-formats.cpp
+++ b/source/dshow-formats.cpp
@@ -48,6 +48,14 @@ const GUID MEDIASUBTYPE_Y800 = {0x30303859,
 				{0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b,
 				 0x71}};
 
+#ifdef ENABLE_HEVC
+const GUID MEDIASUBTYPE_HEVC = {0x43564548,
+				0x0000,
+				0x0010,
+				{0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b,
+				 0x71}};
+#endif
+
 namespace DShow {
 
 DWORD VFormatToFourCC(VideoFormat format)
@@ -86,6 +94,10 @@ DWORD VFormatToFourCC(VideoFormat format)
 		return MAKEFOURCC('M', 'J', 'P', 'G');
 	case VideoFormat::H264:
 		return MAKEFOURCC('H', '2', '6', '4');
+#ifdef ENABLE_HEVC
+	case VideoFormat::HEVC:
+		return MAKEFOURCC('H', 'E', 'V', 'C');
+#endif
 
 	default:
 		return 0;
@@ -126,6 +138,10 @@ GUID VFormatToSubType(VideoFormat format)
 		return MEDIASUBTYPE_MJPG;
 	case VideoFormat::H264:
 		return MEDIASUBTYPE_H264;
+#ifdef ENABLE_HEVC
+	case VideoFormat::HEVC:
+		return MEDIASUBTYPE_HEVC;
+#endif
 
 	default:
 		return GUID();
@@ -237,6 +253,11 @@ static bool GetFourCCVFormat(DWORD fourCC, VideoFormat &format)
 	case MAKEFOURCC('H', '2', '6', '4'):
 		format = VideoFormat::H264;
 		break;
+#ifdef ENABLE_HEVC
+	case MAKEFOURCC('H', 'E', 'V', 'C'):
+		format = VideoFormat::HEVC;
+		break;
+#endif
 
 	/* compressed formats that can automatically create intermediary
 	 * filters for decompression */
@@ -293,6 +314,10 @@ bool GetMediaTypeVFormat(const AM_MEDIA_TYPE &mt, VideoFormat &format)
 	/* compressed formats */
 	else if (mt.subtype == MEDIASUBTYPE_H264)
 		format = VideoFormat::H264;
+#ifdef ENABLE_HEVC
+	else if (mt.subtype == MEDIASUBTYPE_HEVC)
+		format = VideoFormat::HEVC;
+#endif
 
 	/* compressed formats that can automatically create intermediary
 	 * filters for decompression */


### PR DESCRIPTION
### Description
Add support for HEVC video recognition. Compiles safely against obs-studio master, and does not do anything without win-dshow changes, so probably safe to merge.

Merge together with obsproject/obs-studio#6368.

### Motivation and Context
Elgato 4K60 S+ uses HEVC for HDR.

### How Has This Been Tested?
Verified changes compile against obs-studio master branch, and HDR fork.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.