### PR TITLE
Add ability to reactivate if SDR/HDR is toggled

### DIFF
--- a/dshowcapture.hpp
+++ b/dshowcapture.hpp
@@ -59,6 +59,8 @@ typedef std::function<void(const AudioConfig &config, unsigned char *data,
 			   size_t size, long long startTime, long long stopTime)>
 	AudioProc;
 
+typedef std::function<void()> ReactivateProc;
+
 enum class InitGraph {
 	False,
 	True,
@@ -163,6 +165,7 @@ struct Config : DeviceId {
 
 struct VideoConfig : Config {
 	VideoProc callback;
+	ReactivateProc reactivateCallback;
 
 	/** Desired width/height of video. */
 	int cx = 0, cy_abs = 0;

--- a/source/device.cpp
+++ b/source/device.cpp
@@ -112,6 +112,9 @@ void HDevice::Receive(bool isVideo, IMediaSample *sample)
 	if (isVideo ? !videoConfig.callback : !audioConfig.callback)
 		return;
 
+	if (reactivatePending)
+		return;
+
 	/* auto-rotation for devices such as streamcam */
 	if (isVideo && rotatableDevice) {
 		ComQIPtr<IAMCameraControl> cc(videoFilter);
@@ -380,6 +383,9 @@ bool HDevice::SetVideoConfig(VideoConfig *config)
 		Error(L"Could not get video filter");
 		return false;
 	}
+
+	deviceHdrSignal = false;
+	reactivatePending = false;
 
 	videoConfig = *config;
 

--- a/source/device.hpp
+++ b/source/device.hpp
@@ -64,6 +64,8 @@ struct HDevice {
 
 	bool encodedDevice = false;
 	bool rotatableDevice = false;
+	bool deviceHdrSignal = false;
+	bool reactivatePending = false;
 	bool initialized;
 	bool active;
 


### PR DESCRIPTION
### Description
Does nothing without future code changes. Future win-dshow change looks like this:
```
void DShowInput::OnReactivate()
{
	SetActive(true);
}
```

### Motivation and Context
Device needs extra hand-holding to switch video formats, and to reset the device on that switch.

### How Has This Been Tested?
Verified device can handle PS5 SDR/HDR toggle with future code.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.