### PR TITLE
Toggle H264/HEVC according to signal status

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ set(libdshowcapture_SOURCES
 	source/dshowcapture.cpp
 	source/dshowencode.cpp
 	source/device.cpp
+	source/device-vendor.cpp
 	source/encoder.cpp
 	source/dshow-base.cpp
 	source/dshow-demux.cpp

--- a/dshowcapture.hpp
+++ b/dshowcapture.hpp
@@ -99,6 +99,7 @@ enum class VideoFormat {
 	/* encoded formats */
 	MJPEG = 400,
 	H264,
+	HEVC,
 };
 
 enum class AudioFormat {

--- a/source/ComPtr.hpp
+++ b/source/ComPtr.hpp
@@ -53,7 +53,7 @@ public:
 		if (ptr)
 			ptr->AddRef();
 	}
-	inline ComPtr(ComPtr<T> &&c) : ptr(c.ptr) { c.ptr = nullptr; }
+	inline ComPtr(ComPtr<T> &&c) noexcept : ptr(c.ptr) { c.ptr = nullptr; }
 	inline ~ComPtr() { Kill(); }
 
 	inline void Clear()
@@ -76,7 +76,7 @@ public:
 		return *this;
 	}
 
-	inline ComPtr<T> &operator=(ComPtr<T> &&c)
+	inline ComPtr<T> &operator=(ComPtr<T> &&c) noexcept
 	{
 		if (&ptr != &c.ptr) {
 			Kill();

--- a/source/capture-filter.hpp
+++ b/source/capture-filter.hpp
@@ -32,8 +32,8 @@ typedef void (*CaptureCallback)(void *param, IMediaSample *sample);
 
 struct PinCaptureInfo {
 	std::function<void(IMediaSample *sample)> callback;
-	GUID expectedMajorType;
-	GUID expectedSubType;
+	GUID expectedMajorType{};
+	GUID expectedSubType{};
 };
 
 class CapturePin : public IPin, public IMemInputPin {

--- a/source/device-vendor.cpp
+++ b/source/device-vendor.cpp
@@ -1,0 +1,257 @@
+/*
+ *  Copyright (C) 2022 Hugh Bailey <obs.jim@gmail.com>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ */
+
+#include "device.hpp"
+#include "log.hpp"
+
+#include <cinttypes>
+
+namespace DShow {
+
+#define HDMI_INFOFRAME_TYPE_RESERVED 0x00
+#define HDMI_INFOFRAME_TYPE_VS 0x01
+#define HDMI_INFOFRAME_TYPE_AVI 0x02
+#define HDMI_INFOFRAME_TYPE_SPD 0x03
+#define HDMI_INFOFRAME_TYPE_A 0x04
+#define HDMI_INFOFRAME_TYPE_MS 0x05
+#define HDMI_INFOFRAME_TYPE_VBI 0x06
+#define HDMI_INFOFRAME_TYPE_DR 0x07
+
+#define HDMI_DR_EOTF_SDRGAMMA 0x00
+#define HDMI_DR_EOTF_HDRGAMMA 0x01
+#define HDMI_DR_EOTF_ST2084 0x02
+#define HDMI_DR_EOTF_HLG 0x03
+
+typedef struct _HDMI_XY {
+	uint8_t xyz[3];
+} HDMI_XY;
+
+typedef struct _HDMI_DR1_PAYLOAD {
+	uint8_t bfEOTF : 3;
+	uint8_t bfReserved1 : 5;
+
+	uint8_t bfMetadataID : 3;
+	uint8_t bfReserved2 : 5;
+
+	HDMI_XY xyDisplayPrimaries[3];
+	HDMI_XY xyWhitePoint;
+	uint16_t wMaxDisplayLuminance;
+	uint16_t wMinDisplayLuminance;
+	uint16_t wMaxCLL;
+	uint16_t wMaxFALL;
+} HDMI_DR1_PAYLOAD;
+
+typedef struct _HDMI_INFOFRAMEHEADER {
+	uint8_t bfType : 7;
+	uint8_t bfPacketType : 1;
+	uint8_t bfVersion : 7;
+	uint8_t bfChangeBit : 1;
+	uint8_t bPayloadLength;
+} HDMI_INFOFRAMEHEADER;
+
+typedef struct _HDMI_GENERIC_INFOFRAME {
+	HDMI_INFOFRAMEHEADER header;
+	uint8_t bChecksum;
+
+	HDMI_DR1_PAYLOAD plDR1;
+} HDMI_GENERIC_INFOFRAME;
+
+static bool HDMI_IsInfoFrameValid(const _HDMI_GENERIC_INFOFRAME *pInfoFrame)
+{
+	if (pInfoFrame == NULL)
+		return false;
+
+	unsigned char *data = (unsigned char *)pInfoFrame;
+	int size = sizeof(HDMI_INFOFRAMEHEADER) + 1 +
+		   pInfoFrame->header.bPayloadLength;
+
+	unsigned char checksum = 0;
+	while (size-- != 0)
+		checksum += *data++;
+
+	return (checksum == 0);
+}
+
+#define VENDOR_HDMI_PACKET_SIZE 32
+
+enum Properties {
+	GET_HDMI_HDR_PACKET_00_15 = 720,
+	GET_HDMI_HDR_PACKET_16_31 = 721,
+};
+
+static constexpr GUID PROPSETID_4K60S_PLUS = {
+	0xD1E5209F,
+	0x68FD,
+	0x4529,
+	{
+		0xBE,
+		0xE0,
+		0x5E,
+		0x7A,
+		0x1F,
+		0x47,
+		0x92,
+		0x24,
+	},
+};
+
+static HRESULT GetHDMIHDRStatusPacket(IKsPropertySet *propertySet,
+				      uint8_t *outBuffer)
+{
+	DWORD returned;
+	HRESULT res = propertySet->Get(PROPSETID_4K60S_PLUS,
+				       GET_HDMI_HDR_PACKET_00_15, nullptr, 0,
+				       &outBuffer[0], 16, &returned);
+	if (SUCCEEDED(res)) {
+		res = propertySet->Get(PROPSETID_4K60S_PLUS,
+				       GET_HDMI_HDR_PACKET_16_31, nullptr, 0,
+				       &outBuffer[16], 16, &returned);
+	}
+
+	return res;
+}
+
+static bool IsVideoHDRElgato4k60sPlus(IKsPropertySet *propertySet)
+{
+	bool isHDR = false;
+
+	// Try to read HDR meta data
+	static const uint8_t emptyBuffer[VENDOR_HDMI_PACKET_SIZE] = {0};
+	uint8_t buffer[VENDOR_HDMI_PACKET_SIZE] = {0};
+	HRESULT res = GetHDMIHDRStatusPacket(propertySet, buffer);
+	if (SUCCEEDED(res)) {
+		HDMI_GENERIC_INFOFRAME *frame =
+			(_HDMI_GENERIC_INFOFRAME *)(&buffer[0]);
+		bool isInfoFrameValid = HDMI_IsInfoFrameValid(frame);
+		if (isInfoFrameValid) {
+			// Check type in header and EOTF flag in payload
+			if ((HDMI_INFOFRAME_TYPE_DR == frame->header.bfType) &&
+			    HDMI_DR_EOTF_SDRGAMMA != frame->plDR1.bfEOTF) {
+				isHDR = true;
+			} else if (HDMI_INFOFRAME_TYPE_DR ==
+					   frame->header.bfType &&
+				   HDMI_DR_EOTF_SDRGAMMA ==
+					   frame->plDR1.bfEOTF) {
+			} else if (HDMI_INFOFRAME_TYPE_RESERVED ==
+					   frame->header.bfType &&
+				   (0 == memcmp(buffer, emptyBuffer,
+						sizeof(buffer)))) {
+			} else if (HDMI_INFOFRAME_TYPE_DR !=
+				   frame->header.bfType) {
+				Warning(L"HDMI Metadata:  Wrong header type: %d",
+					(int)frame->header.bfType);
+			}
+		} else {
+			Warning(L"HDMI Metadata: HDMI_IsInfoFrameValid() returned error (checksum)!");
+		}
+	}
+
+	return isHDR;
+}
+
+bool IsVendorVideoHDR(IKsPropertySet *propertySet)
+{
+	return IsVideoHDRElgato4k60sPlus(propertySet);
+}
+
+static void SetVideoFormatElgato4k60sPlus(IKsPropertySet *propertySet,
+					  bool hevcTrueAvcFalse)
+{
+	uint32_t propHevcTrueAvcFalse = hevcTrueAvcFalse;
+	const HRESULT hr = propertySet->Set(PROPSETID_4K60S_PLUS, 400, nullptr,
+					    0, &propHevcTrueAvcFalse,
+					    sizeof(propHevcTrueAvcFalse));
+	if (SUCCEEDED(hr))
+		Info(L"Elgato tonemapper Enable=%" PRIu64,
+		     propHevcTrueAvcFalse);
+}
+
+void SetVendorVideoFormat(IKsPropertySet *propertySet, bool hevcTrueAvcFalse)
+{
+	return SetVideoFormatElgato4k60sPlus(propertySet, hevcTrueAvcFalse);
+}
+
+static void SetTonemapperAvermedia(IKsPropertySet *propertySet, bool enable)
+{
+	typedef struct _KSPROPERTY_AVER_HW_HDR2SDR {
+		KSPROPERTY Property;
+		DWORD Enable;
+	} KSPROPERTY_AVER_HW_HDR2SDR, *PKSPROPERTY_AVER_HW_HDR2SDR;
+
+	static constexpr GUID KSPROPSETID_AVER_HDR_PROPERTY = {
+		0X8A80D56F,
+		0XFAC5,
+		0X4692,
+		{
+			0XA4,
+			0X16,
+			0XCF,
+			0X20,
+			0XD4,
+			0XA1,
+			0X8F,
+			0X47,
+		},
+	};
+	KSPROPERTY_AVER_HW_HDR2SDR data{};
+	data.Enable = enable;
+	const HRESULT hr = propertySet->Set(
+		KSPROPSETID_AVER_HDR_PROPERTY, 2, &data.Enable,
+		sizeof(data) - sizeof(data.Property), &data, sizeof(data));
+	if (SUCCEEDED(hr))
+		Info(L"AVerMedia tonemapper Enable=%lu", data.Enable);
+}
+
+static void SetTonemapperElgato(IKsPropertySet *propertySet, bool enable)
+{
+	static constexpr GUID PROPSETID_4K60PROMK2 = {
+		0xD1E5209F,
+		0x68FD,
+		0x4529,
+		{
+			0xBE,
+			0xE0,
+			0x5E,
+			0x7A,
+			0x1F,
+			0x47,
+			0x92,
+			0x26,
+		},
+	};
+	uint32_t propEnable = enable;
+	const HRESULT hr = propertySet->Set(PROPSETID_4K60PROMK2, 722, nullptr,
+					    0, &propEnable, sizeof(propEnable));
+	if (SUCCEEDED(hr))
+		Info(L"Elgato tonemapper Enable=%" PRIu32, propEnable);
+}
+
+void SetVendorTonemapperUsage(IBaseFilter *filter, bool enable)
+{
+	if (filter) {
+		ComPtr<IKsPropertySet> propertySet =
+			ComQIPtr<IKsPropertySet>(filter);
+		if (propertySet) {
+			SetTonemapperAvermedia(propertySet, enable);
+			SetTonemapperElgato(propertySet, enable);
+		}
+	}
+}
+
+} /* namespace DShow */

--- a/source/device.cpp
+++ b/source/device.cpp
@@ -136,6 +136,7 @@ void HDevice::Receive(bool isVideo, IMediaSample *sample)
 			const bool hdr = IsVendorVideoHDR(propertySet);
 			if (deviceHdrSignal != hdr) {
 				deviceHdrSignal = hdr;
+				SetVendorVideoFormat(propertySet, hdr);
 				videoConfig.reactivateCallback();
 				reactivatePending = true;
 				return;
@@ -409,6 +410,7 @@ bool HDevice::SetVideoConfig(VideoConfig *config)
 	ComPtr<IKsPropertySet> propertySet = ComQIPtr<IKsPropertySet>(filter);
 	if (propertySet) {
 		const bool hdr = IsVendorVideoHDR(propertySet);
+		SetVendorVideoFormat(propertySet, hdr);
 		deviceHdrSignal = hdr;
 	}
 

--- a/source/dshow-formats.cpp
+++ b/source/dshow-formats.cpp
@@ -215,6 +215,9 @@ static bool GetFourCCVFormat(DWORD fourCC, VideoFormat &format)
 	case MAKEFOURCC('Y', '8', '0', '0'):
 		format = VideoFormat::Y800;
 		break;
+	case MAKEFOURCC('P', '0', '1', '0'):
+		format = VideoFormat::P010;
+		break;
 
 	/* packed YUV formats */
 	case MAKEFOURCC('Y', 'V', 'Y', 'U'):

--- a/source/dshow-formats.cpp
+++ b/source/dshow-formats.cpp
@@ -48,6 +48,12 @@ const GUID MEDIASUBTYPE_Y800 = {0x30303859,
 				{0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b,
 				 0x71}};
 
+const GUID MEDIASUBTYPE_HEVC = {0x43564548,
+				0x0000,
+				0x0010,
+				{0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b,
+				 0x71}};
+
 namespace DShow {
 
 DWORD VFormatToFourCC(VideoFormat format)
@@ -86,6 +92,8 @@ DWORD VFormatToFourCC(VideoFormat format)
 		return MAKEFOURCC('M', 'J', 'P', 'G');
 	case VideoFormat::H264:
 		return MAKEFOURCC('H', '2', '6', '4');
+	case VideoFormat::HEVC:
+		return MAKEFOURCC('H', 'E', 'V', 'C');
 
 	default:
 		return 0;
@@ -126,6 +134,8 @@ GUID VFormatToSubType(VideoFormat format)
 		return MEDIASUBTYPE_MJPG;
 	case VideoFormat::H264:
 		return MEDIASUBTYPE_H264;
+	case VideoFormat::HEVC:
+		return MEDIASUBTYPE_HEVC;
 
 	default:
 		return GUID();
@@ -237,6 +247,9 @@ static bool GetFourCCVFormat(DWORD fourCC, VideoFormat &format)
 	case MAKEFOURCC('H', '2', '6', '4'):
 		format = VideoFormat::H264;
 		break;
+	case MAKEFOURCC('H', 'E', 'V', 'C'):
+		format = VideoFormat::HEVC;
+		break;
 
 	/* compressed formats that can automatically create intermediary
 	 * filters for decompression */
@@ -293,6 +306,8 @@ bool GetMediaTypeVFormat(const AM_MEDIA_TYPE &mt, VideoFormat &format)
 	/* compressed formats */
 	else if (mt.subtype == MEDIASUBTYPE_H264)
 		format = VideoFormat::H264;
+	else if (mt.subtype == MEDIASUBTYPE_HEVC)
+		format = VideoFormat::HEVC;
 
 	/* compressed formats that can automatically create intermediary
 	 * filters for decompression */

--- a/source/dshow-media-type.hpp
+++ b/source/dshow-media-type.hpp
@@ -64,8 +64,10 @@ public:
 	{
 		AM_MEDIA_TYPE *ptr =
 			(AM_MEDIA_TYPE *)CoTaskMemAlloc(sizeof(*ptr));
-		memset(ptr, 0, sizeof(*ptr));
-		CopyMediaType(ptr, &type);
+		if (ptr) {
+			memset(ptr, 0, sizeof(*ptr));
+			CopyMediaType(ptr, &type);
+		}
 		return ptr;
 	}
 


### PR DESCRIPTION
### Description
Only matters for Elgato 40K60 S+ devices.

TODO: Merge #41 and #40.
TODO: OBS would need to enable HEVC support... which may be a long ways away.

### Motivation and Context
Non-tonemapped HDR image is only available on the HEVC stream.

### How Has This Been Tested?
Works on experimental HDR branch. Have toggle HDR on/off many times on PS5.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.