### PR TITLE
Reimplement Elgato support on top of submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/capture-device-support"]
+	path = external/capture-device-support
+	url = https://github.com/elgatosf/capture-device-support

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,10 @@ if(MINGW)
 endif()
 
 set(libdshowcapture_SOURCES
+    external/capture-device-support/Library/EGAVResult.cpp
+    external/capture-device-support/Library/ElgatoUVCDevice.cpp
+    external/capture-device-support/Library/win/EGAVHIDImplementation.cpp
+    external/capture-device-support/SampleCode/DriverInterface.cpp
     source/capture-filter.cpp
     source/output-filter.cpp
     source/dshowcapture.cpp
@@ -106,6 +110,12 @@ set(libdshowcapture_HEADERS
 
 add_library(libdshowcapture ${libdshowcapture_SOURCES}
                             ${libdshowcapture_HEADERS})
+
+target_include_directories(
+  libdshowcapture
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/external/capture-device-support/Library)
+
+target_compile_definitions(libdshowcapture PRIVATE _UP_WINDOWS=1)
 
 target_link_libraries(libdshowcapture PRIVATE setupapi strmiids ksuser winmm
                                               wmcodecdspuuid)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,105 +4,108 @@ project(libdshowcapture)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
-OPTION(BUILD_SHARED_LIBS "Build shared library" ON)
+option(BUILD_SHARED_LIBS "Build shared library" ON)
 
 find_package(CXX11 REQUIRED)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX11_FLAGS}")
 
-if(${CMAKE_C_COMPILER_ID} MATCHES "Clang" OR ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-	set(CMAKE_COMPILER_IS_CLANG TRUE)
+if(${CMAKE_C_COMPILER_ID} MATCHES "Clang" OR ${CMAKE_CXX_COMPILER_ID} MATCHES
+                                             "Clang")
+  set(CMAKE_COMPILER_IS_CLANG TRUE)
 endif()
 
-if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
-	set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wno-unused-function -Werror-implicit-function-declaration -Wno-missing-field-initializers ${CMAKE_CXX_FLAGS} -fno-strict-aliasing")
-	set(CMAKE_C_FLAGS "-Wall -Wextra -Wno-unused-function -Werror-implicit-function-declaration -Wno-missing-braces -Wno-missing-field-initializers ${CMAKE_C_FLAGS} -std=gnu99 -fno-strict-aliasing")
-	
-	option(USE_LIBC++ "Use libc++ instead of libstdc++" ${APPLE})
-	if(USE_LIBC++)
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-	endif()
-elseif(MSVC)
-	if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
-		string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-	else()
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
-	endif()
+if(CMAKE_COMPILER_IS_GNUCC
+   OR CMAKE_COMPILER_IS_GNUCXX
+   OR CMAKE_COMPILER_IS_CLANG)
+  set(CMAKE_CXX_FLAGS
+      "-Wall -Wextra -Wno-unused-function -Werror-implicit-function-declaration -Wno-missing-field-initializers ${CMAKE_CXX_FLAGS} -fno-strict-aliasing"
+  )
+  set(CMAKE_C_FLAGS
+      "-Wall -Wextra -Wno-unused-function -Werror-implicit-function-declaration -Wno-missing-braces -Wno-missing-field-initializers ${CMAKE_C_FLAGS} -std=gnu99 -fno-strict-aliasing"
+  )
 
-	# Disable pointless constant condition warnings
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4127 /wd4201")
+  option(USE_LIBC++ "Use libc++ instead of libstdc++" ${APPLE})
+  if(USE_LIBC++)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+  endif()
+elseif(MSVC)
+  if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
+    string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+  else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
+  endif()
+
+  # Disable pointless constant condition warnings
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4127 /wd4201")
 endif()
 
 if(WIN32)
-	add_definitions(-DUNICODE -D_UNICODE)
-	if (BUILD_SHARED_LIBS)
-		add_definitions(-DDSHOWCAPTURE_EXPORTS)
-	endif()
+  add_definitions(-DUNICODE -D_UNICODE)
+  if(BUILD_SHARED_LIBS)
+    add_definitions(-DDSHOWCAPTURE_EXPORTS)
+  endif()
 endif()
 
 if(MSVC)
-	set(CMAKE_C_FLAGS_DEBUG "/DDEBUG=1 /D_DEBUG=1 ${CMAKE_C_FLAGS_DEBUG}")
-	set(CMAKE_CXX_FLAGS_DEBUG "/DDEBUG=1 /D_DEBUG=1 ${CMAKE_C_FLAGS_DEBUG}")
+  set(CMAKE_C_FLAGS_DEBUG "/DDEBUG=1 /D_DEBUG=1 ${CMAKE_C_FLAGS_DEBUG}")
+  set(CMAKE_CXX_FLAGS_DEBUG "/DDEBUG=1 /D_DEBUG=1 ${CMAKE_C_FLAGS_DEBUG}")
 
-	if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
-		set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SAFESEH:NO")
-		set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /SAFESEH:NO")
-		set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} /SAFESEH:NO")
-	endif()
+  if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SAFESEH:NO")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /SAFESEH:NO")
+    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} /SAFESEH:NO")
+  endif()
 else()
-	if(MINGW)
-		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_WIN32_WINNT=0x0600 -DWINVER=0x0600")
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_WIN32_WINNT=0x0600 -DWINVER=0x0600")
-	endif()
-	set(CMAKE_C_FLAGS_DEBUG "-DDEBUG=1 -D_DEBUG=1 ${CMAKE_C_FLAGS_DEBUG}")
-	set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG=1 -D_DEBUG=1 ${CMAKE_CXX_FLAGS_DEBUG}")
+  if(MINGW)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_WIN32_WINNT=0x0600 -DWINVER=0x0600")
+    set(CMAKE_CXX_FLAGS
+        "${CMAKE_CXX_FLAGS} -D_WIN32_WINNT=0x0600 -DWINVER=0x0600")
+  endif()
+  set(CMAKE_C_FLAGS_DEBUG "-DDEBUG=1 -D_DEBUG=1 ${CMAKE_C_FLAGS_DEBUG}")
+  set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG=1 -D_DEBUG=1 ${CMAKE_CXX_FLAGS_DEBUG}")
 endif()
 
 if(MINGW)
-    include (CheckSymbolExists)
-    check_symbol_exists(MINGW_HAS_SECURE_API "_mingw.h" HAVE_MINGW_HAS_SECURE_API)
-    if(NOT HAVE_MINGW_HAS_SECURE_API)
-        message(FATAL_ERROR "mingw must be compiled with --enable-secure-api")
-    endif()
+  include(CheckSymbolExists)
+  check_symbol_exists(MINGW_HAS_SECURE_API "_mingw.h" HAVE_MINGW_HAS_SECURE_API)
+  if(NOT HAVE_MINGW_HAS_SECURE_API)
+    message(FATAL_ERROR "mingw must be compiled with --enable-secure-api")
+  endif()
 endif()
 
 set(libdshowcapture_SOURCES
-	source/capture-filter.cpp
-	source/output-filter.cpp
-	source/dshowcapture.cpp
-	source/dshowencode.cpp
-	source/device.cpp
-	source/device-vendor.cpp
-	source/encoder.cpp
-	source/dshow-base.cpp
-	source/dshow-demux.cpp
-	source/dshow-enum.cpp
-	source/dshow-formats.cpp
-	source/dshow-media-type.cpp
-	source/dshow-encoded-device.cpp
-	source/log.cpp)
+    source/capture-filter.cpp
+    source/output-filter.cpp
+    source/dshowcapture.cpp
+    source/dshowencode.cpp
+    source/device.cpp
+    source/device-vendor.cpp
+    source/encoder.cpp
+    source/dshow-base.cpp
+    source/dshow-demux.cpp
+    source/dshow-enum.cpp
+    source/dshow-formats.cpp
+    source/dshow-media-type.cpp
+    source/dshow-encoded-device.cpp
+    source/log.cpp)
 
 set(libdshowcapture_HEADERS
-	dshowcapture.hpp
-	source/external/IVideoCaptureFilter.h
-	source/capture-filter.hpp
-	source/output-filter.hpp
-	source/device.hpp
-	source/encoder.hpp
-	source/dshow-base.hpp
-	source/dshow-demux.hpp
-	source/dshow-device-defs.hpp
-	source/dshow-enum.hpp
-	source/dshow-formats.hpp
-	source/dshow-media-type.hpp
-	source/log.hpp)
+    dshowcapture.hpp
+    source/external/IVideoCaptureFilter.h
+    source/capture-filter.hpp
+    source/output-filter.hpp
+    source/device.hpp
+    source/encoder.hpp
+    source/dshow-base.hpp
+    source/dshow-demux.hpp
+    source/dshow-device-defs.hpp
+    source/dshow-enum.hpp
+    source/dshow-formats.hpp
+    source/dshow-media-type.hpp
+    source/log.hpp)
 
-add_library(libdshowcapture
-	${libdshowcapture_SOURCES}
-	${libdshowcapture_HEADERS})
+add_library(libdshowcapture ${libdshowcapture_SOURCES}
+                            ${libdshowcapture_HEADERS})
 
-target_link_libraries(libdshowcapture PRIVATE
-	setupapi
-	strmiids
-	ksuser
-	winmm
-	wmcodecdspuuid)
+target_link_libraries(libdshowcapture PRIVATE setupapi strmiids ksuser winmm
+                                              wmcodecdspuuid)

--- a/source/device-vendor.cpp
+++ b/source/device-vendor.cpp
@@ -17,6 +17,8 @@
  *  USA
  */
 
+#include <ElgatoUVCDevice.h>
+#include "../external/capture-device-support/SampleCode/DriverInterface.h"
 #include "device.hpp"
 #include "log.hpp"
 
@@ -24,167 +26,23 @@
 
 namespace DShow {
 
-#define HDMI_INFOFRAME_TYPE_RESERVED 0x00
-#define HDMI_INFOFRAME_TYPE_VS 0x01
-#define HDMI_INFOFRAME_TYPE_AVI 0x02
-#define HDMI_INFOFRAME_TYPE_SPD 0x03
-#define HDMI_INFOFRAME_TYPE_A 0x04
-#define HDMI_INFOFRAME_TYPE_MS 0x05
-#define HDMI_INFOFRAME_TYPE_VBI 0x06
-#define HDMI_INFOFRAME_TYPE_DR 0x07
-
-#define HDMI_DR_EOTF_SDRGAMMA 0x00
-#define HDMI_DR_EOTF_HDRGAMMA 0x01
-#define HDMI_DR_EOTF_ST2084 0x02
-#define HDMI_DR_EOTF_HLG 0x03
-
-typedef struct _HDMI_XY {
-	uint8_t xyz[3];
-} HDMI_XY;
-
-typedef struct _HDMI_DR1_PAYLOAD {
-	uint8_t bfEOTF : 3;
-	uint8_t bfReserved1 : 5;
-
-	uint8_t bfMetadataID : 3;
-	uint8_t bfReserved2 : 5;
-
-	HDMI_XY xyDisplayPrimaries[3];
-	HDMI_XY xyWhitePoint;
-	uint16_t wMaxDisplayLuminance;
-	uint16_t wMinDisplayLuminance;
-	uint16_t wMaxCLL;
-	uint16_t wMaxFALL;
-} HDMI_DR1_PAYLOAD;
-
-typedef struct _HDMI_INFOFRAMEHEADER {
-	uint8_t bfType : 7;
-	uint8_t bfPacketType : 1;
-	uint8_t bfVersion : 7;
-	uint8_t bfChangeBit : 1;
-	uint8_t bPayloadLength;
-} HDMI_INFOFRAMEHEADER;
-
-typedef struct _HDMI_GENERIC_INFOFRAME {
-	HDMI_INFOFRAMEHEADER header;
-	uint8_t bChecksum;
-
-	HDMI_DR1_PAYLOAD plDR1;
-} HDMI_GENERIC_INFOFRAME;
-
-static bool HDMI_IsInfoFrameValid(const _HDMI_GENERIC_INFOFRAME *pInfoFrame)
-{
-	if (pInfoFrame == NULL)
-		return false;
-
-	unsigned char *data = (unsigned char *)pInfoFrame;
-	int size = sizeof(HDMI_INFOFRAMEHEADER) + 1 +
-		   pInfoFrame->header.bPayloadLength;
-
-	unsigned char checksum = 0;
-	while (size-- != 0)
-		checksum += *data++;
-
-	return (checksum == 0);
-}
-
-#define VENDOR_HDMI_PACKET_SIZE 32
-
-enum Properties {
-	GET_HDMI_HDR_PACKET_00_15 = 720,
-	GET_HDMI_HDR_PACKET_16_31 = 721,
-};
-
-static constexpr GUID PROPSETID_4K60S_PLUS = {
-	0xD1E5209F,
-	0x68FD,
-	0x4529,
-	{
-		0xBE,
-		0xE0,
-		0x5E,
-		0x7A,
-		0x1F,
-		0x47,
-		0x92,
-		0x24,
-	},
-};
-
-static HRESULT GetHDMIHDRStatusPacket(IKsPropertySet *propertySet,
-				      uint8_t *outBuffer)
-{
-	DWORD returned;
-	HRESULT res = propertySet->Get(PROPSETID_4K60S_PLUS,
-				       GET_HDMI_HDR_PACKET_00_15, nullptr, 0,
-				       &outBuffer[0], 16, &returned);
-	if (SUCCEEDED(res)) {
-		res = propertySet->Get(PROPSETID_4K60S_PLUS,
-				       GET_HDMI_HDR_PACKET_16_31, nullptr, 0,
-				       &outBuffer[16], 16, &returned);
-	}
-
-	return res;
-}
-
-static bool IsVideoHDRElgato4k60sPlus(IKsPropertySet *propertySet)
-{
-	bool isHDR = false;
-
-	// Try to read HDR meta data
-	static const uint8_t emptyBuffer[VENDOR_HDMI_PACKET_SIZE] = {0};
-	uint8_t buffer[VENDOR_HDMI_PACKET_SIZE] = {0};
-	HRESULT res = GetHDMIHDRStatusPacket(propertySet, buffer);
-	if (SUCCEEDED(res)) {
-		HDMI_GENERIC_INFOFRAME *frame =
-			(_HDMI_GENERIC_INFOFRAME *)(&buffer[0]);
-		bool isInfoFrameValid = HDMI_IsInfoFrameValid(frame);
-		if (isInfoFrameValid) {
-			// Check type in header and EOTF flag in payload
-			if ((HDMI_INFOFRAME_TYPE_DR == frame->header.bfType) &&
-			    HDMI_DR_EOTF_SDRGAMMA != frame->plDR1.bfEOTF) {
-				isHDR = true;
-			} else if (HDMI_INFOFRAME_TYPE_DR ==
-					   frame->header.bfType &&
-				   HDMI_DR_EOTF_SDRGAMMA ==
-					   frame->plDR1.bfEOTF) {
-			} else if (HDMI_INFOFRAME_TYPE_RESERVED ==
-					   frame->header.bfType &&
-				   (0 == memcmp(buffer, emptyBuffer,
-						sizeof(buffer)))) {
-			} else if (HDMI_INFOFRAME_TYPE_DR !=
-				   frame->header.bfType) {
-				Warning(L"HDMI Metadata:  Wrong header type: %d",
-					(int)frame->header.bfType);
-			}
-		} else {
-			Warning(L"HDMI Metadata: HDMI_IsInfoFrameValid() returned error (checksum)!");
-		}
-	}
-
-	return isHDR;
-}
-
 bool IsVendorVideoHDR(IKsPropertySet *propertySet)
 {
-	return IsVideoHDRElgato4k60sPlus(propertySet);
-}
-
-static void SetVideoFormatElgato4k60sPlus(IKsPropertySet *propertySet,
-					  bool hevcTrueAvcFalse)
-{
-	uint32_t propHevcTrueAvcFalse = hevcTrueAvcFalse;
-	const HRESULT hr = propertySet->Set(PROPSETID_4K60S_PLUS, 400, nullptr,
-					    0, &propHevcTrueAvcFalse,
-					    sizeof(propHevcTrueAvcFalse));
-	if (SUCCEEDED(hr))
-		Info(L"Elgato tonemapper Enable=%" PRIu64,
-		     propHevcTrueAvcFalse);
+	EGAVDeviceProperties properties(
+		propertySet, EGAVDeviceProperties::DeviceType::GC4K60SPlus);
+	bool isHDR = false;
+	return SUCCEEDED(properties.IsVideoHDR(isHDR)) ? isHDR : false;
 }
 
 void SetVendorVideoFormat(IKsPropertySet *propertySet, bool hevcTrueAvcFalse)
 {
-	return SetVideoFormatElgato4k60sPlus(propertySet, hevcTrueAvcFalse);
+	EGAVDeviceProperties properties(
+		propertySet, EGAVDeviceProperties::DeviceType::GC4K60SPlus);
+	const HRESULT hr = properties.SetEncoderType(hevcTrueAvcFalse);
+	if (SUCCEEDED(hr)) {
+		Info(L"Elgato GC4K60SPlus encoder type=%ls",
+		     hevcTrueAvcFalse ? L"HEVC" : L"AVC");
+	}
 }
 
 static void SetTonemapperAvermedia(IKsPropertySet *propertySet, bool enable)
@@ -215,31 +73,26 @@ static void SetTonemapperAvermedia(IKsPropertySet *propertySet, bool enable)
 		KSPROPSETID_AVER_HDR_PROPERTY, 2, &data.Enable,
 		sizeof(data) - sizeof(data.Property), &data, sizeof(data));
 	if (SUCCEEDED(hr))
-		Info(L"AVerMedia tonemapper Enable=%lu", data.Enable);
+		Info(L"AVerMedia tonemapper enable=%lu", data.Enable);
 }
 
 static void SetTonemapperElgato(IKsPropertySet *propertySet, bool enable)
 {
-	static constexpr GUID PROPSETID_4K60PROMK2 = {
-		0xD1E5209F,
-		0x68FD,
-		0x4529,
-		{
-			0xBE,
-			0xE0,
-			0x5E,
-			0x7A,
-			0x1F,
-			0x47,
-			0x92,
-			0x26,
-		},
-	};
-	uint32_t propEnable = enable;
-	const HRESULT hr = propertySet->Set(PROPSETID_4K60PROMK2, 722, nullptr,
-					    0, &propEnable, sizeof(propEnable));
-	if (SUCCEEDED(hr))
-		Info(L"Elgato tonemapper Enable=%" PRIu32, propEnable);
+	EGAVDeviceProperties properties(
+		propertySet, EGAVDeviceProperties::DeviceType::GC4K60ProMK2);
+	const HRESULT hr = properties.SetHDRTonemapping(enable);
+	if (SUCCEEDED(hr)) {
+		Info(L"Elgato GC4K60ProMK2 tonemapper enable=%d", (int)enable);
+	} else {
+		std::shared_ptr<EGAVHIDInterface> hid =
+			CreateEGAVHIDInterface();
+		if (hid->InitHIDInterface(deviceIDHD60SPlus).Succeeded()) {
+			ElgatoUVCDevice device(hid, false);
+			device.SetHDRTonemappingEnabled(enable);
+			Info(L"Elgato HD60SPlus tonemapper enable=%d",
+			     (int)enable);
+		}
+	}
 }
 
 void SetVendorTonemapperUsage(IBaseFilter *filter, bool enable)


### PR DESCRIPTION
### Description
Elgato has provided a submodule to support their devices, so use it. Also add support for HD60 S+.

### Motivation and Context
Easier integration of bug fixes, and new device support.

### How Has This Been Tested?
- [x] libdshowcapture submodule compiles by itself.
- [x] Verify automatic HDR toggle for 4K60 Pro MK.2 has not regressed.
- [x] Verify automatic HDR toggle for 4K60 S+ has not regressed.
- [x] Verify automatic HDR toggle for HD60 S+ works now.
- [x] Verify automatic HDR toggle for HD60 X has not regressed.

### Types of changes
- New feature (non-breaking change which adds functionality)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.