### PR TITLE
Add support for AverMedia coupled audio

### DIFF
--- a/source/dshow-base.cpp
+++ b/source/dshow-base.cpp
@@ -693,6 +693,7 @@ static bool IsUncoupledDevice(const wchar_t *vidDevInstPath)
 		L"0FD9", /* elgato */
 		L"3842", /* evga */
 		L"0B05", /* asus */
+		L"07CA", /* avermedia */
 	};
 
 	if (MatchingStartToken(path, usbToken)) {


### PR DESCRIPTION
### Description

Adds Avermedia's vendor ID to the automatic audio device discovery whitelist.

### Motivation and Context

Makes life easier.

### How Has This Been Tested?

Hasn't.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
