### PR TITLE
Disable clang-format for submodules

### DIFF
--- a/external/.clang-format
+++ b/external/.clang-format
@@ -1,0 +1,3 @@
+Language: Cpp
+SortIncludes: false
+DisableFormat: true


### PR DESCRIPTION
### Description

Ignores items in the `external/` folder when running clang-format on a project.

### Motivation and Context

Have you ever gotten annoyed that running the formatting script results in a submodule change on your Mac?
Have you ever had to manually go in and `git reset --hard` that folder just to get a clean `git status` output?

Well I have so that's why I added this (btw no clue why this doesn't cause issues on CI)

### How Has This Been Tested?

Ran locally, no longer formats that folder.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:


- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
