### PR TITLE
Support more capture cards with uncoupled audio

### DIFF
--- a/source/dshow-base.cpp
+++ b/source/dshow-base.cpp
@@ -694,6 +694,21 @@ static bool IsUncoupledDevice(const wchar_t *vidDevInstPath)
 		L"3842", /* evga */
 		L"0B05", /* asus */
 		L"07CA", /* avermedia */
+		L"048D", /* digitnow/pengo */
+		L"04B4", /* mokose */
+		L"0557", /* aten */
+		L"1164", /* startek/kapchr */
+		L"1532", /* razer */
+		L"1BCF", /* mypin/treaslin/mirabox */
+		L"1E4E", /* pengo/cloneralliance */
+		L"1E71", /* nzxt */
+		L"2040", /* hauppauge */
+		L"2935", /* magewell */
+		L"298F", /* genki */
+		L"2B77", /* epiphan */
+		L"32ED", /* ezcap */
+		L"534D", /* brand-less/pacoxi/ucec */
+		L"EBA4", /* zasluke */
 	};
 
 	if (MatchingStartToken(path, usbToken)) {
@@ -711,6 +726,8 @@ static bool IsUncoupledDevice(const wchar_t *vidDevInstPath)
 	const wstring pciSubsysToken = L"SUBSYS_";
 	const wstring pciVenIdWhitelist[] = {
 		L"1CD7", /* magewell */
+		L"8888", /* acasis */
+		L"1461", /* avermedia */
 	};
 	const wstring pciSubsysIdWhitelist[] = {
 		L"1CFA", /* elgato */


### PR DESCRIPTION
### Description

Continuing the efforts from previous PRs, this introduces a list of IDs for both USB and PCIe capture cards to allow for better default audio capture on a variety of devices.

Thanks to @EposVox for compiling a list.

Note: I wasn't 100% sure whether to put PCI cards under Ven ID or Subsys ID (both values match each other for the 2 new respective entries.

Avermedia: `\\?\pci#ven_1461&dev_0054&subsys_57001461&rev_00`
ACASIS: `\\?\pci#ven_8888&dev_8504&subsys_00078888&rev_00`

### Motivation and Context

Better audio support means less support questions

### How Has This Been Tested?

Hasn't been tested directly.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
