### PR TITLE
Add OutputFilter constructor without video format

### DIFF
--- a/source/output-filter.cpp
+++ b/source/output-filter.cpp
@@ -35,9 +35,11 @@ namespace DShow {
 #define VIDEO_PIN_NAME L"Video Output"
 #define AUDIO_PIN_NAME L"Audio Output"
 
+OutputPin::OutputPin(OutputFilter *filter_) : refCount(0), filter(filter_) {}
+
 OutputPin::OutputPin(OutputFilter *filter_, VideoFormat format, int cx, int cy,
 		     long long interval)
-	: refCount(0), filter(filter_)
+	: OutputPin(filter_)
 {
 	curCX = cx;
 	curCY = cy;
@@ -644,6 +646,15 @@ public:
 		return AM_FILTER_MISC_FLAGS_IS_SOURCE;
 	}
 };
+
+OutputFilter::OutputFilter()
+	: refCount(0),
+	  state(State_Stopped),
+	  graph(nullptr),
+	  pin(new OutputPin(this)),
+	  misc(new SourceMiscFlags)
+{
+}
 
 OutputFilter::OutputFilter(VideoFormat format, int cx, int cy,
 			   long long interval)

--- a/source/output-filter.hpp
+++ b/source/output-filter.hpp
@@ -37,9 +37,9 @@ class OutputPin : public IPin, public IAMStreamConfig, public IKsPropertySet {
 
 	MediaType mt;
 	VideoFormat curVFormat;
-	long long curInterval;
-	int curCX;
-	int curCY;
+	long long curInterval = 0;
+	int curCX = 0;
+	int curCY = 0;
 	bool setSampleMediaType = false;
 
 	ComPtr<IPin> connectedPin;
@@ -54,6 +54,7 @@ class OutputPin : public IPin, public IAMStreamConfig, public IKsPropertySet {
 	bool AllocateBuffers(IPin *target, bool connecting = false);
 
 public:
+	OutputPin(OutputFilter *filter);
 	OutputPin(OutputFilter *filter, VideoFormat format, int cx, int cy,
 		  long long interval);
 	virtual ~OutputPin();
@@ -143,6 +144,7 @@ protected:
 	ComPtr<IReferenceClock> clock;
 
 public:
+	OutputFilter();
 	OutputFilter(VideoFormat format, int cx, int cy, long long interval);
 	virtual ~OutputFilter();
 


### PR DESCRIPTION
### Description
Add constructor without format

### Motivation and Context
This allows you to create OutputFilter without AddVideoFormat being called
This way the virtual camera can be made to not always AddVideoFormat with the hardcoded default format (1920x1080)
This is needed for https://github.com/obsproject/obs-studio/pull/7934

### How Has This Been Tested?
On windows 64bit with https://github.com/obsproject/obs-studio/pull/7934

### Types of changes
- New feature (non-breaking change which adds functionality) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
