### PR TITLE
fix: Force syncpoint on everysample

### DIFF
--- a/source/output-filter.cpp
+++ b/source/output-filter.cpp
@@ -547,6 +547,8 @@ bool OutputPin::LockSampleData(unsigned char **ptr)
 		return false;
 	if (FAILED(sample->SetPreroll(false)))
 		return false;
+	if (FAILED(sample->SetSyncPoint(true)))
+		return false;
 	if (FAILED(sample->GetPointer(ptr)))
 		return false;
 


### PR DESCRIPTION
### Description
This changes every sample to clearly state that they are sync points.

### Motivation and Context
As the virtual camera always sends frames that are uncompressed and/or keyframes the best is to always mark these samples as such. When not doing this I was having issues in Resolume Arena that sometimes the OBS stream would show up and on other times it would not and the virtualcam filter would not transition into running state properly.

`IMediaControl->Run()` would only call into the `Pause` call on the filter but not the `Run` call, not always sometimes it would work, so I guess this memory was 'uninitialized' when not set explicitly.

### How Has This Been Tested?
Running aforementioned software with and without this change. Tested on Windows 11, core i9.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
