### PR TITLE
Add audio buffer option to audio config

### DIFF
--- a/dshowcapture.hpp
+++ b/dshowcapture.hpp
@@ -208,6 +208,9 @@ struct AudioConfig : Config {
 
 	/** Audio playback mode */
 	AudioMode mode = AudioMode::Capture;
+
+	/** Desired buffer */
+	int buffer = 0;
 };
 
 class DSHOWCAPTURE_EXPORT Device {

--- a/source/device.cpp
+++ b/source/device.cpp
@@ -802,7 +802,7 @@ bool HDevice::ConnectFilters()
 				     std::string::npos);
 
 		if (!streamEngine && audioCapture != nullptr)
-			SetAudioBuffering(10);
+			SetAudioBuffering(audioConfig.buffer ? audioConfig.buffer : 10);
 
 		success = ConnectPins(PIN_CATEGORY_CAPTURE, MEDIATYPE_Audio,
 				      audioFilter, filter);


### PR DESCRIPTION
Description

This adds an option to set the audio buffer, rather than be forced to use 10ms.

Motivation and Context

I am trialing the library in a personal hobby project and I found that with a 10ms buffer, I was getting audio glitches so I needed to raise it. 80ms is apparently recommended by MSDN, and 50ms is the default used inside FFmpeg.

How Has This Been Tested?

Testing with my project shows the audio is more stable when I increase the buffer.

Types of changes

Tweak (non-breaking change to improve existing functionality)

Checklist:

 My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
 I have read the [contributing document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
 My code is not on the master branch.
 The code has been tested.
 All commit messages are properly formatted and commits squashed where appropriate.
 I have included updates to all appropriate documentation.