### PR TITLE
Support new Elgato devices

### DIFF
--- a/source/device-vendor.cpp
+++ b/source/device-vendor.cpp
@@ -175,11 +175,13 @@ static void SetTonemapperElgato(IKsPropertySet *propertySet, bool enable)
 	} else {
 		std::shared_ptr<EGAVHIDInterface> hid =
 			CreateEGAVHIDInterface();
-		if (hid->InitHIDInterface(deviceIDHD60SPlus).Succeeded()) {
-			ElgatoUVCDevice device(hid, false);
-			device.SetHDRTonemappingEnabled(enable);
-			Info(L"Elgato HD60SPlus tonemapper enable=%d",
-			     (int)enable);
+		for (auto &deviceID : GetElgatoUVCDeviceIDs()) {
+			if (hid->InitHIDInterface(deviceID).Succeeded()) {
+				ElgatoUVCDevice device(hid, false);
+				device.SetHDRTonemappingEnabled(enable);
+				Info(L"Elgato UVC device (PID = 0x04X%d) tonemapper enable=%d",
+				     deviceID.productID, (int)enable);
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description
Update Elgato's submodule `capture-device-support` to add HDR support for a new revision of the HD60 X.

### Motivation and Context
Whenver new Elgato capture devices are released the Elgato SDK needs to be updated.

### How Has This Been Tested?
I connected the new HD60 X Rev.2  to my PC and tested that the Elgato sample app in the SDK can successfully detect HDR and switch the tone-mapping. I double-checked with older devices HD60 S+ and HD60 X (rev.1).
I ran the tests on Windows.

### Types of changes
<!--- - Tweak (non-breaking change to improve existing functionality) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
