### PR TITLE
use unique name as path

### DIFF
--- a/source/dshow-enum.cpp
+++ b/source/dshow-enum.cpp
@@ -472,8 +472,15 @@ static bool EnumDevice(const GUID &type, IMoniker *deviceInfo,
 		return true;
 	}
 
-	propertyData->Read(L"DevicePath", &devicePath, NULL);
-
+	LPOLESTR displayName = NULL;
+	hr = deviceInfo->GetDisplayName(NULL, NULL, &displayName);
+	if (SUCCEEDED(hr))
+	{
+		devicePath.vt = VT_BSTR;
+		devicePath.bstrVal = SysAllocString(displayName);
+		CoTaskMemFree(displayName);
+	}
+	
 	hr = deviceInfo->BindToObject(NULL, 0, IID_IBaseFilter,
 				      (void **)&filter);
 	if (SUCCEEDED(hr)) {


### PR DESCRIPTION
the `devicePath` usually does not work for virtual devices, the path will be empty, this new way will work for both physics audio/video devices and virtual devices btw, FFmpeg uses this way as the unique path too.