### PR TITLE
Fix typo in comment

### DIFF
--- a/dshowcapture.hpp
+++ b/dshowcapture.hpp
@@ -190,7 +190,7 @@ struct AudioConfig : Config {
 	/**
 		 * Use the audio attached to the video device
 		 *
-		 * (name/path memeber variables will be ignored)
+		 * (name/path member variables will be ignored)
 		 */
 	bool useVideoDevice = false;
 


### PR DESCRIPTION
- Related: https://github.com/obsproject/obs-studio/issues/11160

### Description

Fixes a spelling mistakes in comments

### Motivation and Context

Proper English makes log-messages, documentation and code more readable.

### How Has This Been Tested?

still builds

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!-- - Documentation (a change to documentation pages)  -->

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
