### PR TITLE
Fix raw formats

### DIFF
--- a/source/dshow-formats.cpp
+++ b/source/dshow-formats.cpp
@@ -283,7 +283,7 @@ bool GetMediaTypeVFormat(const AM_MEDIA_TYPE &mt, VideoFormat &format)
 
 	/* raw formats */
 	if (mt.subtype == MEDIASUBTYPE_RGB24)
-		format = VideoFormat::XRGB;
+		format = VideoFormat::RGB24;
 	else if (mt.subtype == MEDIASUBTYPE_RGB32)
 		format = VideoFormat::XRGB;
 	else if (mt.subtype == MEDIASUBTYPE_ARGB32)


### PR DESCRIPTION
### Description
directshow claims that the color format supported is MEDIASUBTYPE_RGB24, and it should correspond to VideoFormat::RGB24 instead of VideoFormat::XRGB

### Motivation and Context
This change is completely self-explanatory

### How Has This Been Tested?
I have wrote the following test code and tested multiple camera devices that support RGB24 format on Windows 10, and now it can provide the correct format.
```cpp
#include <ole2.h>
#include <cstdio>
#include "dshowcapture.hpp"

const char *format2str(DShow::VideoFormat format) {
    switch (format) {
        case DShow::VideoFormat::Any:
            return "Any";
        default:
        case DShow::VideoFormat::Unknown:
            return "Unknown";
        case DShow::VideoFormat::ARGB:
            return "ARGB";
        case DShow::VideoFormat::XRGB:
            return "XRGB";
        case DShow::VideoFormat::RGB24:
            return "RGB";
        case DShow::VideoFormat::I420:
            return "I420";
        case DShow::VideoFormat::NV12:
            return "NV12";
        case DShow::VideoFormat::YV12:
            return "YV12";
        case DShow::VideoFormat::Y800:
            return "Y800";
        case DShow::VideoFormat::YVYU:
            return "YVYU";
        case DShow::VideoFormat::YUY2:
            return "YUY2";
        case DShow::VideoFormat::UYVY:
            return "UYVY";
        case DShow::VideoFormat::HDYC:
            return "HDYC";
        case DShow::VideoFormat::MJPEG:
            return "MJPEG";
        case DShow::VideoFormat::H264:
            return "H264";
    }
}

int main() {
    CoInitialize(nullptr);

    std::vector<DShow::VideoDevice> devices;
    if (!DShow::Device::EnumVideoDevices(devices)) {
        printf("ERROR! Unable to list video devices\n");
        return -1;
    }

    if (devices.empty()) {
        printf("ERROR! No video devices found\n");
        return -1;
    }

    printf("Devices:\n");
    for (int i = 0; i < devices.size(); i++) {
        const auto &device = devices[i];
        printf("----------------------------------\n");
        printf("- Device %d:\n", i);
        wprintf(L"  - Device: %s\n", device.name.c_str());
        wprintf(L"  - Path: %s\n", device.path.c_str());
        printf("  - Caps:\n");
        for (const auto &cap : device.caps) {
            printf("    - %dx%d %s\n", cap.minCX, cap.minCY, format2str(cap.format));
        }
    }

    return 0;
}
```

### Types of changes
Bug fix

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
